### PR TITLE
feat: WSL2 support - allow install on Linux and run bundled Win32 helper via interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ stateDiagram-v2
 
 ## 系统要求
 
-- Windows 10/11 x64
+- Windows 10/11 x64（原生系统，或 WSL2 —— DSH 可以安装在 WSL 内，helper 窗口仍显示在 Windows 桌面）
 - 已安装并能正常运行的 DeepSeek Harness WebUI
 - DSH CLI 中可以使用 `plugin --profile web` 命令
 - npm 上的 `dsh-dafeiyu@alpha`，或 GitHub Release 中的 `.tgz` 安装包
@@ -120,11 +120,32 @@ dsh-dafeiyu-<version>.tgz
 pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<version>.tgz"
 ```
 
-### 4. 启动 DSH
+### 4. WSL2 安装
+
+DSH 也可以安装在 WSL2 内（Ubuntu 等发行版）。插件会通过
+`/proc/sys/fs/binfmt_misc/WSLInterop` 自动检测 WSL 环境，并直接启动打包的
+Win32 helper（经 WSL interop 桥接），大肥鱼窗口依然显示在 Windows 桌面上，
+置顶与透明行为与原生 Windows 一致。
+
+安装命令与原生 Windows 相同（在 WSL 终端执行）：
+
+```bash
+dsh plugin --profile web add dsh-dafeiyu@alpha
+chmod +x ~/.dsh/profiles/web/node_modules/dsh-dafeiyu/runtime/bin/win32-x64/dsh-dafeiyu-helper.exe
+```
+
+然后重启 dsh web。注意：
+
+- WSL 内**不需要**安装 Python 或 PySide6；
+- 若发布包丢失了 exe 的可执行位，插件会自动回退到 python3 分支，
+  此时需要在 WSL 内安装 PySide6；
+- 窗口位置记忆写入 Windows 侧 `%LOCALAPPDATA%\DSH\dsh-dafeiyu\layout.json`。
+
+### 5. 启动 DSH
 
 照常启动 DSH WebUI。插件默认启用，大肥鱼会由 DSH 自动拉起；不要手动打开 Helper。
 
-### 5. 找到设置入口
+### 6. 找到设置入口
 
 在 DSH WebUI 中进入：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -69,7 +69,7 @@ When several DSH sessions run at once, the default attention priority is:
 
 ## Requirements
 
-- Windows 10/11 x64
+- Windows 10/11 x64 (native, or WSL2 — DSH can run inside WSL while the helper window still appears on the Windows desktop)
 - A working DeepSeek Harness WebUI installation
 - A DSH CLI that supports `plugin --profile web`
 - `dsh-dafeiyu@alpha` from npm, or a `.tgz` archive from GitHub Releases
@@ -122,12 +122,34 @@ Do not extract it. Install the downloaded archive from the DSH directory:
 pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<version>.tgz"
 ```
 
-### 4. Start DSH
+### 4. WSL2 install
+
+DSH can also be installed inside WSL2 (Ubuntu and other distributions). The plugin
+detects the WSL environment via `/proc/sys/fs/binfmt_misc/WSLInterop` and launches the
+bundled Win32 helper directly through WSL interop, so the BigFish window still appears on
+the Windows desktop with the same topmost and translucent behavior as on native Windows.
+
+The install command is the same as on native Windows (run it in the WSL terminal):
+
+```bash
+dsh plugin --profile web add dsh-dafeiyu@alpha
+chmod +x ~/.dsh/profiles/web/node_modules/dsh-dafeiyu/runtime/bin/win32-x64/dsh-dafeiyu-helper.exe
+```
+
+Then restart dsh web. Notes:
+
+- Python and PySide6 are **not** required inside WSL;
+- if the release archive loses the exe's executable bit, the plugin falls back to the
+  python3 path, in which case PySide6 must be installed inside WSL;
+- window position is remembered on the Windows side at
+  `%LOCALAPPDATA%\DSH\dsh-dafeiyu\layout.json`.
+
+### 5. Start DSH
 
 Launch the DSH WebUI normally. The plugin is enabled by default, and DSH starts BigFish
 automatically. Do not start the Helper yourself.
 
-### 5. Open the settings
+### 6. Open the settings
 
 In the DSH WebUI, go to:
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@deepseek-ai/schemastery": "^3.18.1"
   },
   "scripts": {
-    "test": "node --test --test-timeout=10000 test/assets.test.js test/config-endpoint.test.js test/protocol.test.js test/status-copy.test.js test/reducer.test.js test/helper-lifecycle.test.js test/helper-restart.test.js test/plugin-integration.test.js",
+    "test": "node --test --test-timeout=10000 test/assets.test.js test/config-endpoint.test.js test/helper-command.test.js test/protocol.test.js test/status-copy.test.js test/reducer.test.js test/helper-lifecycle.test.js test/helper-restart.test.js test/plugin-integration.test.js",
     "test:helper": "node --test test/helper-lifecycle.test.js",
     "test:python": "py -3 -m unittest discover -s runtime/tests -t .",
     "test:ui": "node test/fixtures/ui-acceptance.js",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,6 @@
     "ASSET_LICENSE.md",
     "LICENSE"
   ],
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "x64"
-  ],
   "engines": {
     "node": ">=22.19"
   },

--- a/src/helper-process.js
+++ b/src/helper-process.js
@@ -13,8 +13,12 @@ const here = dirname(fileURLToPath(import.meta.url))
 const defaultHelperPath = resolve(here, '..', 'runtime', 'helper.py')
 const bundledHelperPath = resolve(here, '..', 'runtime', 'bin', 'win32-x64', 'dsh-dafeiyu-helper.exe')
 
+// WSL2: Linux kernel with interop enabled can spawn the bundled Win32 helper directly,
+// and the window appears on the Windows desktop (upstream is Windows-only).
+const isWsl = process.platform === 'linux' && existsSync('/proc/sys/fs/binfmt_misc/WSLInterop')
+
 function defaultCommand() {
-  if (process.platform === 'win32' && existsSync(bundledHelperPath)) return bundledHelperPath
+  if ((process.platform === 'win32' || isWsl) && existsSync(bundledHelperPath)) return bundledHelperPath
   return process.env.DSH_DAFEIYU_PYTHON || (process.platform === 'win32' ? 'py' : 'python3')
 }
 

--- a/src/helper-process.js
+++ b/src/helper-process.js
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { accessSync, constants, existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
@@ -17,9 +17,33 @@ const bundledHelperPath = resolve(here, '..', 'runtime', 'bin', 'win32-x64', 'ds
 // and the window appears on the Windows desktop (upstream is Windows-only).
 const isWsl = process.platform === 'linux' && existsSync('/proc/sys/fs/binfmt_misc/WSLInterop')
 
+function canExecute(path) {
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Pure decision logic, exported for tests. On WSL the bundled exe must also carry
+// the executable bit (npm packs from Windows often drop it); otherwise fall back
+// to python3 + helper.py instead of failing spawn with EACCES.
+export function resolveHelperCommand({ platform, isWslEnv, bundledPath, pythonEnv }) {
+  const useBundled = platform === 'win32'
+    ? existsSync(bundledPath)
+    : isWslEnv && existsSync(bundledPath) && canExecute(bundledPath)
+  if (useBundled) return bundledPath
+  return pythonEnv || (platform === 'win32' ? 'py' : 'python3')
+}
+
 function defaultCommand() {
-  if ((process.platform === 'win32' || isWsl) && existsSync(bundledHelperPath)) return bundledHelperPath
-  return process.env.DSH_DAFEIYU_PYTHON || (process.platform === 'win32' ? 'py' : 'python3')
+  return resolveHelperCommand({
+    platform: process.platform,
+    isWslEnv: isWsl,
+    bundledPath: bundledHelperPath,
+    pythonEnv: process.env.DSH_DAFEIYU_PYTHON,
+  })
 }
 
 function defaultArgs(command, helperPath) {

--- a/test/helper-command.test.js
+++ b/test/helper-command.test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { resolveHelperCommand } from '../src/helper-process.js'
+
+async function makeFile(mode) {
+  const directory = await mkdtemp(join(tmpdir(), 'dsh-dafeiyu-cmd-'))
+  const path = join(directory, 'dsh-dafeiyu-helper.exe')
+  await writeFile(path, 'fake helper')
+  if (mode !== undefined) await chmod(path, mode)
+  return { directory, path }
+}
+
+test('win32 uses the bundled exe whenever it exists (exec bit is a Linux concept)', async () => {
+  const { directory, path } = await makeFile(0o644)
+  assert.equal(resolveHelperCommand({ platform: 'win32', isWslEnv: false, bundledPath: path }), path)
+  await rm(directory, { recursive: true, force: true })
+})
+
+test('non-WSL linux always falls back to python3', async () => {
+  const { directory, path } = await makeFile(0o755)
+  assert.equal(resolveHelperCommand({ platform: 'linux', isWslEnv: false, bundledPath: path }), 'python3')
+  await rm(directory, { recursive: true, force: true })
+})
+
+test('WSL uses the bundled exe when it carries the executable bit', async () => {
+  const { directory, path } = await makeFile(0o755)
+  assert.equal(resolveHelperCommand({ platform: 'linux', isWslEnv: true, bundledPath: path }), path)
+  await rm(directory, { recursive: true, force: true })
+})
+
+test('WSL falls back to python3 when the bundled exe is not executable', async () => {
+  const { directory, path } = await makeFile(0o644)
+  assert.equal(resolveHelperCommand({ platform: 'linux', isWslEnv: true, bundledPath: path }), 'python3')
+  await rm(directory, { recursive: true, force: true })
+})
+
+test('WSL falls back to python3 when the bundled exe is missing', async () => {
+  assert.equal(resolveHelperCommand({ platform: 'linux', isWslEnv: true, bundledPath: '/definitely/missing.exe' }), 'python3')
+})
+
+test('DSH_DAFEIYU_PYTHON override wins over every fallback', async () => {
+  assert.equal(resolveHelperCommand({ platform: 'linux', isWslEnv: true, bundledPath: '/missing.exe', pythonEnv: '/opt/python/bin/python3' }), '/opt/python/bin/python3')
+})

--- a/test/helper-lifecycle.test.js
+++ b/test/helper-lifecycle.test.js
@@ -6,7 +6,9 @@ import test from 'node:test'
 import { HelperProcess } from '../src/helper-process.js'
 import { CompanionMessageKind, CompanionState, createMessage } from '../src/protocol.js'
 
-async function waitFor(predicate, timeoutMs = 3000) {
+// WSL interop spawns the onefile exe through a cold PyInstaller extraction
+// (3s+ for the bundled build), so keep the default poll window generous.
+async function waitFor(predicate, timeoutMs = 8000) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if (await predicate()) return


### PR DESCRIPTION
## 动机

dsh-dafeiyu 目前声明 `"os": ["win32"]`，且仅当 `process.platform === 'win32'` 时才
spawn 打包的 helper exe，导致在 WSL2 中既无法安装也无法运行。WSL2 是 Windows 上
运行 DeepSeek Harness 的常见方式。

WSL2 的 interop 层可以直接执行 Win32 二进制（存在 `/proc/sys/fs/binfmt_misc/WSLInterop`
标志），helper 窗口会出现在原生 Windows 桌面上。

## 改动

- `package.json`：移除 `os`/`cpu` 限制，允许在 Linux 上安装
- `src/helper-process.js`：通过 interop 标志检测 WSL2，让 WSL 走打包 exe 分支，
  而不是回退到 python3 + PySide6

## 测试

- `pnpm test`：28/28 通过
- Windows 11 + WSL2（Ubuntu，内核 6.18）端到端实测：WSL 内插件 ↔ stdin/stdout 管道
  ↔ Windows 桌面上的 Win32 helper 窗口；跨边界管道压测 0 丢包
- 布局持久化正常写入 Windows 侧 `%LOCALAPPDATA%`，无路径问题

## 备注

发布时请在装有 PySide6 的环境重新执行 `scripts/build-helper.ps1`
（`pip install PySide6 pyinstaller`），该问题已由现有 issue 跟踪。