### PR TITLE
Fix alpha.8 packaging and DSH state handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Changelog
 
+## 0.1.0-alpha.8
+
+Packaging and DSH event-state hotfix release.
+
+### Fixed
+
+- Restored the Windows visual Helper after `0.1.0-alpha.7` was published without PySide6/Qt
+- Stopped thinking-card copy from changing on every streamed assistant chunk ([#5](https://github.com/QCYTSN/dsh-dafeiyu/issues/5))
+- Added real DSH `tool/result` call-ID paths so completed tools no longer leave stale working stages ([#6](https://github.com/QCYTSN/dsh-dafeiyu/issues/6))
+- Added a dedicated waiting state for `ask_user_question`, `request_user_input`, and equivalent user-question tools ([#6](https://github.com/QCYTSN/dsh-dafeiyu/issues/6))
+
+### Release safeguards
+
+- The Windows build now fails before packaging unless the selected Python can import both PyInstaller and PySide6
+- Every packaged Helper must start, complete the protocol handshake, render a real Qt snapshot with bundled assets, and shut down cleanly
+- The public incident and resolution are tracked in [#7](https://github.com/QCYTSN/dsh-dafeiyu/issues/7)
+
+### Update
+
+Fully exit DSH, then run:
+
+```powershell
+dsh plugin --profile web update dsh-dafeiyu@alpha
+```
+
+Restart DSH after the update. Existing `0.1.0-alpha.7` users should update directly to this version.
+
 ## 0.1.0-alpha.7
+
+> **Known broken release:** the published Windows Helper omitted PySide6/Qt. The WebUI settings
+> panel loads, but the desktop companion cannot appear. Use `0.1.0-alpha.6` or update to
+> `0.1.0-alpha.8`. See [#7](https://github.com/QCYTSN/dsh-dafeiyu/issues/7).
 
 Animation and live-settings refinement release.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 入口属于 DSH，生命周期属于 DSH，显示层属于桌面。
 
-[English](README_EN.md) · [npm](https://www.npmjs.com/package/dsh-dafeiyu) · [下载最新版本](https://github.com/QCYTSN/dsh-dafeiyu/releases/latest) · [更新与回退](docs/UPDATING.md) · [验收记录](docs/ACCEPTANCE.md)
+[English](README_EN.md) · [npm](https://www.npmjs.com/package/dsh-dafeiyu) · [下载最新版本](https://github.com/QCYTSN/dsh-dafeiyu/releases/latest) · [更新日志](CHANGELOG.md) · [更新与回退](docs/UPDATING.md) · [验收记录](docs/ACCEPTANCE.md)
 
 </div>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,7 +6,7 @@
 
 Enabled by DSH, owned by the DSH lifecycle, rendered on the desktop.
 
-[中文](README.md) · [npm](https://www.npmjs.com/package/dsh-dafeiyu) · [Latest release](https://github.com/QCYTSN/dsh-dafeiyu/releases/latest) · [Update and rollback](docs/UPDATING.md) · [Acceptance notes](docs/ACCEPTANCE.md)
+[中文](README.md) · [npm](https://www.npmjs.com/package/dsh-dafeiyu) · [Latest release](https://github.com/QCYTSN/dsh-dafeiyu/releases/latest) · [Changelog](CHANGELOG.md) · [Update and rollback](docs/UPDATING.md) · [Acceptance notes](docs/ACCEPTANCE.md)
 
 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-dafeiyu",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "A desktop-native BigFish companion driven by DeepSeek Harness session events.",
   "author": "QCYTSN",
   "type": "module",
@@ -21,6 +21,7 @@
     "runtime/__init__.py",
     "runtime/bin/win32-x64/dsh-dafeiyu-helper.exe",
     "scripts/build-helper.ps1",
+    "scripts/test-packaged-helper.mjs",
     "assets/pet/",
     "assets/pet-manifest.json",
     "docs/",
@@ -51,7 +52,8 @@
     "test:ui": "node test/fixtures/ui-acceptance.js",
     "helper:headless": "py -3 runtime/helper.py --headless",
     "helper:visual": "py -3 runtime/helper.py",
-    "build:helper:windows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-helper.ps1"
+    "build:helper:windows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-helper.ps1",
+    "test:helper:packaged": "node scripts/test-packaged-helper.mjs"
   },
   "dsh": {
     "client": {

--- a/scripts/build-helper.ps1
+++ b/scripts/build-helper.ps1
@@ -8,12 +8,18 @@ $entry = Join-Path $projectRoot 'runtime\helper.py'
 $assets = Join-Path $projectRoot 'assets'
 $output = Join-Path $projectRoot 'runtime\bin\win32-x64'
 $work = Join-Path $projectRoot '.build\helper'
+$projectPython = Join-Path $projectRoot '.build\python-env\Scripts\python.exe'
 
 if (-not $Python) {
-  $Python = 'python'
+  $Python = if (Test-Path -LiteralPath $projectPython) { $projectPython } else { 'python' }
 }
 
 New-Item -ItemType Directory -Force -Path $output, $work | Out-Null
+
+& $Python -c "import PyInstaller, PySide6; print(f'PyInstaller {PyInstaller.__version__}; PySide6 {PySide6.__version__}')"
+if ($LASTEXITCODE -ne 0) {
+  throw "The selected Python cannot import both PyInstaller and PySide6. Install requirements into the same interpreter or set DSH_DAFEIYU_BUILD_PYTHON. Selected: $Python"
+}
 
 & $Python -m PyInstaller `
   --noconfirm `
@@ -32,4 +38,10 @@ if ($LASTEXITCODE -ne 0) {
   throw "PyInstaller failed with exit code $LASTEXITCODE"
 }
 
-Write-Output (Join-Path $output 'dsh-dafeiyu-helper.exe')
+$executable = Join-Path $output 'dsh-dafeiyu-helper.exe'
+& node (Join-Path $PSScriptRoot 'test-packaged-helper.mjs') --executable $executable
+if ($LASTEXITCODE -ne 0) {
+  throw "Packaged helper visual smoke test failed with exit code $LASTEXITCODE"
+}
+
+Write-Output $executable

--- a/scripts/test-packaged-helper.mjs
+++ b/scripts/test-packaged-helper.mjs
@@ -1,0 +1,87 @@
+import { spawn } from 'node:child_process'
+import { mkdir, rm, stat } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const projectRoot = resolve(scriptDirectory, '..')
+const argument = (name) => {
+  const index = process.argv.indexOf(name)
+  return index >= 0 ? process.argv[index + 1] : undefined
+}
+const executable = resolve(argument('--executable')
+  ?? resolve(projectRoot, 'runtime/bin/win32-x64/dsh-dafeiyu-helper.exe'))
+const snapshot = resolve(argument('--snapshot')
+  ?? resolve(projectRoot, '.build/helper/packaged-visual-smoke.png'))
+const timeoutMs = Number(argument('--timeout-ms') ?? 15_000)
+
+await stat(executable)
+await mkdir(dirname(snapshot), { recursive: true })
+await rm(snapshot, { force: true })
+
+const child = spawn(executable, ['--snapshot', snapshot], {
+  stdio: ['pipe', 'pipe', 'pipe'],
+  windowsHide: true,
+})
+let standardError = ''
+let standardOutput = ''
+child.stderr.setEncoding('utf8')
+child.stdout.setEncoding('utf8')
+child.stderr.on('data', (chunk) => { standardError += chunk })
+child.stdout.on('data', (chunk) => { standardOutput += chunk })
+
+const exit = new Promise((resolveExit) => {
+  child.once('exit', (code, signal) => resolveExit({ code, signal }))
+})
+const delay = (milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds))
+const waitUntil = async (predicate, label) => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await predicate()) return
+    if (child.exitCode !== null) {
+      throw new Error(`${label}: helper exited early with code ${child.exitCode}. ${standardError}`)
+    }
+    await delay(50)
+  }
+  throw new Error(`${label}: timed out after ${timeoutMs} ms. stdout=${standardOutput} stderr=${standardError}`)
+}
+
+try {
+  await waitUntil(() => standardOutput.includes('"kind": "ready"'), 'ready handshake')
+  child.stdin.write(`${JSON.stringify({
+    protocolVersion: 1,
+    kind: 'state',
+    timestamp: Date.now(),
+    state: 'WORKING',
+    activity: 'testing',
+    message: 'Packaged visual smoke test',
+    detail: 'Qt renderer and assets are available',
+  })}\n`)
+  await waitUntil(async () => {
+    try {
+      return (await stat(snapshot)).size > 1024
+    } catch {
+      return false
+    }
+  }, 'visual snapshot')
+  child.stdin.end(`${JSON.stringify({
+    protocolVersion: 1,
+    kind: 'shutdown',
+    timestamp: Date.now(),
+  })}\n`)
+  const result = await Promise.race([
+    exit,
+    delay(5_000).then(() => ({ timeout: true })),
+  ])
+  if (result.timeout) {
+    child.kill()
+    throw new Error('helper did not exit after shutdown')
+  }
+  if (result.code !== 0) {
+    throw new Error(`helper exited with code ${result.code}. ${standardError}`)
+  }
+  console.log(`Packaged helper visual smoke test passed: ${snapshot}`)
+} catch (error) {
+  if (child.exitCode === null) child.kill()
+  throw error
+}

--- a/src/companion-reducer.js
+++ b/src/companion-reducer.js
@@ -28,6 +28,24 @@ function toolActivity(name) {
   return 'using-tool'
 }
 
+function toolCallIdOf(event, fallback = '') {
+  const content = event?.data?.message?.content
+  const contentCallId = Array.isArray(content)
+    ? content.find((item) => item?.toolCallId)?.toolCallId
+    : undefined
+  return String(event?.data?.message?.source?.callId
+    ?? contentCallId
+    ?? event?.data?.message?.toolCallId
+    ?? event?.data?.message?.callId
+    ?? event?.data?.callId
+    ?? fallback)
+}
+
+function isUserQuestionTool(name) {
+  const value = String(name || '').toLowerCase()
+  return /ask.*user.*question|request.*user.*input|user[-_/.:]?questions?/u.test(value)
+}
+
 function sessionIdOf(session) {
   return String(session?.header?.id ?? session?.id ?? 'unknown-session')
 }
@@ -116,6 +134,7 @@ export class CompanionReducer {
       case 'turn/start':
         record.turnActive = true
         record.openTools.clear()
+        record.waitingCallId = undefined
         record.task = undefined
         record.progress = undefined
         this.#update(record, CompanionState.THINKING, {
@@ -129,18 +148,29 @@ export class CompanionReducer {
       case 'assistant/chunk':
       case 'assistant/message':
         if (!record.turnActive || record.openTools.size > 0) return []
+        if (record.state === CompanionState.THINKING && record.payload.phase === 'thinking') return []
         this.#update(record, CompanionState.THINKING, {
-          phase: event.type,
+          phase: 'thinking',
           stage: '分析阶段',
           message: statusCopy('thinking', event.seq),
         })
         return this.#render()
 
       case 'tool/call': {
-        const callId = String(event.data?.callId ?? `seq-${String(event.seq ?? 'unknown')}`)
-        const name = String(event.data?.name ?? 'tool')
-        const activity = toolActivity(name)
+        const callId = toolCallIdOf(event, `seq-${String(event.seq ?? 'unknown')}`)
+        const name = String(event.data?.name ?? event.data?.message?.name ?? 'tool')
         record.openTools.set(callId, name)
+        if (isUserQuestionTool(name)) {
+          record.waitingCallId = callId
+          this.#update(record, CompanionState.WAITING, {
+            phase: 'user-question',
+            stage: '等待确认',
+            toolName: name,
+            message: statusCopy('waiting', event.seq),
+          })
+          return this.#render()
+        }
+        const activity = toolActivity(name)
         this.#update(record, CompanionState.WORKING, {
           phase: 'tool-call',
           activity,
@@ -153,6 +183,9 @@ export class CompanionReducer {
 
       case 'tool/result':
         return this.#toolResult(record, event)
+
+      case 'user/message':
+        return this.#userMessage(record, event)
 
       case 'todo/write':
         return this.#todo(record, event)
@@ -173,11 +206,23 @@ export class CompanionReducer {
   }
 
   #toolResult(record, event) {
-    const callId = String(event.data?.message?.toolCallId
-      ?? event.data?.message?.callId
-      ?? event.data?.callId
-      ?? '')
+    const callId = toolCallIdOf(event)
     if (callId) record.openTools.delete(callId)
+    if (callId && callId === record.waitingCallId) record.waitingCallId = undefined
+    return this.#resumeAfterTool(record, event)
+  }
+
+  #userMessage(record, event) {
+    if (!record.waitingCallId) return []
+    record.openTools.delete(record.waitingCallId)
+    record.waitingCallId = undefined
+    return this.#resumeAfterTool(record, event)
+  }
+
+  #resumeAfterTool(record, event) {
+    if (record.waitingCallId && record.openTools.has(record.waitingCallId)) {
+      return this.#render()
+    }
     const next = record.openTools.size > 0 ? CompanionState.WORKING : CompanionState.THINKING
     const nextPayload = {
       phase: 'tool-result',
@@ -244,6 +289,7 @@ export class CompanionReducer {
   #turnEnd(record, event) {
     record.turnActive = false
     record.openTools.clear()
+    record.waitingCallId = undefined
     const kind = String(event.data?.reason?.kind ?? 'completed')
 
     if (kind === 'blocked') {
@@ -310,6 +356,7 @@ export class CompanionReducer {
       payload: { phase: 'session-created', message: 'DSH 空闲中' },
       turnActive: false,
       openTools: new Map(),
+      waitingCallId: undefined,
       task: undefined,
       progress: undefined,
       project: undefined,
@@ -381,4 +428,4 @@ export class CompanionReducer {
   }
 }
 
-export { statePriority, toolActivity }
+export { isUserQuestionTool, statePriority, toolActivity, toolCallIdOf }

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -38,6 +38,73 @@ test('turn and tool events produce stable companion states', () => {
   assert.equal(complete.resumeState, CompanionState.IDLE)
 })
 
+test('assistant chunks keep one stable thinking message within the same phase', () => {
+  const reducer = new CompanionReducer()
+  reducer.handle(session, event('turn/start', { turn: 1 }, 1))
+
+  const [thinking] = reducer.handle(session, event('assistant/chunk', {
+    message: { content: '第一段' },
+  }, 2))
+  assert.equal(thinking.state, CompanionState.THINKING)
+  assert.equal(thinking.phase, 'thinking')
+
+  assert.deepEqual(reducer.handle(session, event('assistant/chunk', {
+    message: { content: '第二段' },
+  }, 3)), [])
+  assert.deepEqual(reducer.handle(session, event('assistant/message', {
+    message: { content: '完整消息' },
+  }, 4)), [])
+})
+
+test('real DSH tool result callId paths clear completed tools', () => {
+  const reducer = new CompanionReducer()
+  reducer.handle(session, event('turn/start', { turn: 1 }, 1))
+  reducer.handle(session, event('tool/call', { callId: 'source-call', name: 'read_file' }, 2))
+
+  const [afterSourceResult] = reducer.handle(session, event('tool/result', {
+    message: { source: { callId: 'source-call' } },
+  }, 3))
+  assert.equal(afterSourceResult.state, CompanionState.THINKING)
+
+  reducer.handle(session, event('tool/call', { callId: 'content-call', name: 'shell_command' }, 4))
+  const [afterContentResult] = reducer.handle(session, event('tool/result', {
+    message: { content: [{ type: 'tool-result', toolCallId: 'content-call' }] },
+  }, 5))
+  assert.equal(afterContentResult.state, CompanionState.THINKING)
+})
+
+test('question tools show waiting and resume on result or user response', () => {
+  const reducer = new CompanionReducer()
+  reducer.handle(session, event('turn/start', { turn: 1 }, 1))
+
+  const [waitingForResult] = reducer.handle(session, event('tool/call', {
+    callId: 'question-one',
+    name: 'ask_user_question',
+  }, 2))
+  assert.equal(waitingForResult.state, CompanionState.WAITING)
+  assert.equal(waitingForResult.stage, '等待确认')
+
+  assert.deepEqual(reducer.handle(session, event('tool/result', {
+    message: { source: { callId: 'unrelated-call' } },
+  }, 3)), [])
+
+  const [resumedFromResult] = reducer.handle(session, event('tool/result', {
+    message: { source: { callId: 'question-one' } },
+  }, 4))
+  assert.equal(resumedFromResult.state, CompanionState.THINKING)
+
+  const [waitingForUser] = reducer.handle(session, event('tool/call', {
+    callId: 'question-two',
+    name: 'request_user_input',
+  }, 5))
+  assert.equal(waitingForUser.state, CompanionState.WAITING)
+
+  const [resumedFromUser] = reducer.handle(session, event('user/message', {
+    message: { content: '继续' },
+  }, 6))
+  assert.equal(resumedFromUser.state, CompanionState.THINKING)
+})
+
 test('tool failure pulses error without losing the underlying work state', () => {
   const reducer = new CompanionReducer()
   reducer.handle(session, event('turn/start', { turn: 1 }, 1))


### PR DESCRIPTION
## Summary

- restore the Windows visual Helper in `0.1.0-alpha.8` after alpha.7 omitted PySide6/Qt
- stabilize thinking copy and support real DSH tool result call-ID paths
- show WAITING for user-question tools and resume on result/user response
- require build-time PySide6/PyInstaller preflight plus a packaged Qt visual smoke test
- document the incident, fixes, update path, and alpha.7 deprecation

## Verification

- `npm test`: 31/31 passed
- local packaged Helper visual smoke test passed
- fresh install from the public npm registry (`dsh-dafeiyu@0.1.0-alpha.8`) passed the packaged Helper visual smoke test
- public package contains a 50,900,458-byte Windows Helper and rendered a 127,275-byte diagnostic PNG
- npm `alpha` points to `0.1.0-alpha.8`; alpha.7 is deprecated

Closes #5
Closes #6
Closes #7