### PR TITLE
feat: WSL2 support and Issue #12 desktop enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,31 @@
 # Changelog
 
-## 0.1.0-alpha.10 (unreleased)
-
-
+## 0.1.0-alpha.10
 
 WSL2 support and Issue #12 desktop interaction enhancements.
 
-
-
 ### Added
 
-
-
 - WSL2 support: allow installation on Linux and run the bundled Win32 Helper through WSL interop ([#8](https://github.com/QCYTSN/dsh-dafeiyu/pull/8))
-
 - Right-click “打开 WebUI” action to reopen the DSH WebUI from the desktop pet ([#12](https://github.com/QCYTSN/dsh-dafeiyu/issues/12))
-
 - Completion/error alert feedback: beep plus a brief window shake on SUCCESS/ERROR pulses ([#12](https://github.com/QCYTSN/dsh-dafeiyu/issues/12))
-
 - Multi-task status card: when multiple DSH sessions are active, the pet bubble lists the running tasks and their states ([#12](https://github.com/QCYTSN/dsh-dafeiyu/issues/12))
-
-
 
 ### Changed
 
-
-
-- Removed npm `os`/`cpu` package restrictions so WSL2/Linux installs are accepted
-
+- Removed the npm `os` restriction so WSL2 installs are accepted while retaining the x64 CPU requirement
+- WSL2 launches the Helper through `cmd.exe`, so npm's Linux executable bit is not required
 - The helper now snapshots and replays the multi-task list after a restart
+
+### Update
+
+Fully exit DSH, then run:
+
+```powershell
+dsh plugin --profile web update dsh-dafeiyu@alpha
+```
+
+Restart DSH after the update.
 
 ## 0.1.0-alpha.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.1.0-alpha.10 (unreleased)
+
+
+
+WSL2 support and Issue #12 desktop interaction enhancements.
+
+
+
+### Added
+
+
+
+- WSL2 support: allow installation on Linux and run the bundled Win32 Helper through WSL interop ([#8](https://github.com/QCYTSN/dsh-dafeiyu/pull/8))
+
+- Right-click “打开 WebUI” action to reopen the DSH WebUI from the desktop pet ([#12](https://github.com/QCYTSN/dsh-dafeiyu/issues/12))
+
+- Completion/error alert feedback: beep plus a brief window shake on SUCCESS/ERROR pulses ([#12](https://github.com/QCYTSN/dsh-dafeiyu/issues/12))
+
+- Multi-task status card: when multiple DSH sessions are active, the pet bubble lists the running tasks and their states ([#12](https://github.com/QCYTSN/dsh-dafeiyu/issues/12))
+
+
+
+### Changed
+
+
+
+- Removed npm `os`/`cpu` package restrictions so WSL2/Linux installs are accepted
+
+- The helper now snapshots and replays the multi-task list after a restart
+
 ## 0.1.0-alpha.9
 
 Windows drag-stability hotfix release.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DSH 大肥鱼不是一个需要单独启动的桌宠应用。它由 DSH 插件�
 一起启动和退出，并以透明、无边框、始终置顶的原生窗口显示在桌面上。即使切换到
 VS Code、浏览器或文件管理器，也能知道 DSH 当前在思考、修改、测试、等待还是已经完成。
 
-> 当前版本：`0.1.0-alpha.9` · Windows MVP Alpha
+> 当前版本：`0.1.0-alpha.10` · Windows / WSL2 Alpha
 
 ## 它有什么用？
 
@@ -105,6 +105,11 @@ pnpm exec dsh plugin --profile web add dsh-dafeiyu@alpha
 ```powershell
 dsh plugin --profile web add dsh-dafeiyu@alpha
 ```
+
+如果 DSH 运行在 WSL2，请在 WSL 终端执行同一条安装命令。插件会自动通过
+`cmd.exe` 启动包内的 Windows Helper，不需要手动 `chmod`，也不需要在 WSL
+安装 Python 或 PySide6。当前支持范围是 Windows x64 上的 WSL2；普通 Linux、
+远程 Linux 和容器不是本版本的桌面显示目标。
 
 ### 3. GitHub Release 备用安装方式
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ stateDiagram-v2
 
 `等待确认 > 错误 > 工作 > 思考 > 空闲`
 
+当有多个活动任务时，状态气泡会同时列出这些任务的状态。
+
 ## 系统要求
 
-- Windows 10/11 x64
+- Windows 10/11 x64，或 WSL2（通过 Windows interop 运行桌面 Helper）
 - 已安装并能正常运行的 DeepSeek Harness WebUI
 - DSH CLI 中可以使用 `plugin --profile web` 命令
 - npm 上的 `dsh-dafeiyu@alpha`，或 GitHub Release 中的 `.tgz` 安装包
@@ -172,7 +174,7 @@ pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<vers
 
 - **拖动**：按住大肥鱼移动位置，位置会自动保存。
 - **点击或双击**：触发摸头、戳一下、尾巴等短互动，之后恢复最新 DSH 状态。
-- **右键菜单**：调整大小、气泡大小、减少动态、本次隐藏或本次关闭。
+- **右键菜单**：调整大小、气泡大小、减少动态、打开 WebUI、本次隐藏或本次关闭。
 - **本次隐藏**：只隐藏窗口，不禁用插件。
 - **本次关闭**：关闭当前 Helper，本次 DSH 运行期间不会自动重启；下次启动 DSH 会再次出现。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -67,9 +67,11 @@ When several DSH sessions run at once, the default attention priority is:
 
 `Waiting > Error > Working > Thinking > Idle`
 
+When multiple tasks are active, the status bubble lists them at the same time.
+
 ## Requirements
 
-- Windows 10/11 x64
+- Windows 10/11 x64, or WSL2 (runs the desktop Helper through Windows interop)
 - A working DeepSeek Harness WebUI installation
 - A DSH CLI that supports `plugin --profile web`
 - `dsh-dafeiyu@alpha` from npm, or a `.tgz` archive from GitHub Releases
@@ -175,7 +177,7 @@ DSH persists these settings, so a normal plugin update does not require reconfig
 
 - **Drag:** move BigFish; its position is saved automatically.
 - **Click or double-click:** trigger brief head-pat, poke, or tail reactions, then return to the latest DSH state.
-- **Right-click:** change size, bubble size, reduce motion, hide for now, or close for this run.
+- **Right-click:** change size, bubble size, reduce motion, open WebUI, hide for now, or close for this run.
 - **Hide for now:** hides the window without disabling the plugin.
 - **Close for this run:** closes the current Helper and suppresses restart until the next DSH launch.
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -17,7 +17,7 @@ stops its native Helper, and provides the Agent events that drive it. The transp
 frameless companion stays above other Windows apps, so you can see whether DSH is thinking,
 editing, testing, waiting, or finished while working in VS Code, a browser, or File Explorer.
 
-> Current version: `0.1.0-alpha.9` · Windows MVP Alpha
+> Current version: `0.1.0-alpha.10` · Windows / WSL2 Alpha
 
 ## What is it for?
 
@@ -108,6 +108,11 @@ If `dsh` is already available globally, the command is simply:
 dsh plugin --profile web add dsh-dafeiyu@alpha
 ```
 
+When DSH runs inside WSL2, run the same install command in the WSL terminal. The plugin
+launches the bundled Windows Helper through `cmd.exe`; no manual `chmod`, Python, or
+PySide6 installation is required inside WSL. The current target is WSL2 on Windows x64,
+not ordinary Linux, remote Linux, or containers.
+
 ### 3. GitHub Release fallback
 
 Open [GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases/latest) and download:
@@ -115,8 +120,6 @@ Open [GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases/latest) an
 ```text
 dsh-dafeiyu-<version>.tgz
 ```
-
-Do not extract it.
 
 Do not extract it. Install the downloaded archive from the DSH directory:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-dafeiyu",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "A desktop-native BigFish companion driven by DeepSeek Harness session events.",
   "author": "QCYTSN",
   "type": "module",
@@ -33,6 +33,9 @@
     "ASSET_LICENSE.md",
     "LICENSE"
   ],
+  "cpu": [
+    "x64"
+  ],
   "engines": {
     "node": ">=22.19"
   },
@@ -40,7 +43,7 @@
     "@deepseek-ai/schemastery": "^3.18.1"
   },
   "scripts": {
-    "test": "node --test --test-timeout=10000 test/assets.test.js test/config-endpoint.test.js test/protocol.test.js test/status-copy.test.js test/reducer.test.js test/helper-lifecycle.test.js test/helper-restart.test.js test/plugin-integration.test.js",
+    "test": "node --test --test-timeout=10000 test/assets.test.js test/config-endpoint.test.js test/helper-command.test.js test/protocol.test.js test/status-copy.test.js test/reducer.test.js test/helper-lifecycle.test.js test/helper-restart.test.js test/plugin-integration.test.js",
     "test:helper": "node --test test/helper-lifecycle.test.js",
     "test:python": "py -3 -m unittest discover -s runtime/tests -t .",
     "test:ui": "node test/fixtures/ui-acceptance.js",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,6 @@
     "ASSET_LICENSE.md",
     "LICENSE"
   ],
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "x64"
-  ],
   "engines": {
     "node": ">=22.19"
   },

--- a/runtime/helper.py
+++ b/runtime/helper.py
@@ -111,8 +111,8 @@ def run_headless(recorder: EventRecorder) -> int:
 
 def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> int:
     try:
-        from PySide6.QtCore import QObject, QPoint, QRectF, Qt, QTimer, Signal
-        from PySide6.QtGui import QColor, QFont, QFontMetrics, QMouseEvent, QPainter, QPen, QPixmap
+        from PySide6.QtCore import QObject, QPoint, QRectF, Qt, QTimer, QUrl, Signal
+        from PySide6.QtGui import QColor, QDesktopServices, QFont, QFontMetrics, QMouseEvent, QPainter, QPen, QPixmap
         from PySide6.QtWidgets import QApplication, QMenu, QWidget
     except ImportError:
         print(
@@ -192,6 +192,11 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             self.overlay_detail = ""
             self.overlay_deadline_ms: int | None = None
             self.task = ""
+            self.tasks: list[dict[str, Any]] = []
+            self.webui_url = os.environ.get("DSH_DAFEIYU_WEBUI_URL", "http://127.0.0.1:3080/")
+            self.shake_timer: QTimer | None = None
+            self.shake_origin: QPoint | None = None
+            self.shake_count = 0
             self.drag_origin: QPoint | None = None
             self.pet_origin: QPoint | None = None
             self.pet_x = 0
@@ -236,6 +241,11 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                     self.model.base_state,
                     None if self.model.base_state in {"THINKING", "WORKING", "WAITING", "ERROR"} else 6000,
                 )
+            elif kind == "tasks":
+                raw_tasks = message.get("tasks")
+                self.tasks = raw_tasks if isinstance(raw_tasks, list) else []
+                self._apply_window_size()
+                self._move_to_pet(self.pet_x, self.pet_y)
             elif kind == "config":
                 self._apply_config(message)
             elif kind in {"state", "pulse"}:
@@ -263,6 +273,8 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                         state,
                         ttl_ms,
                     )
+                    if state in {"SUCCESS", "ERROR"}:
+                        self._notify_alert(state)
                 else:
                     activity = None if self.reduced_motion else message.get("activity")
                     self.model.apply_state(state, activity)
@@ -404,7 +416,7 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             pet_width = round(int(manifest["maxFrameWidth"]) * self.scale)
             pet_height = round(int(manifest["maxFrameHeight"]) * self.scale)
             bubble_width = round(420 * self.bubble_scale)
-            bubble_height = round(84 * self.bubble_scale)
+            bubble_height = self._card_height()
             self.setFixedSize(max(pet_width + 50, bubble_width + 28), pet_height + bubble_height + 34)
 
         def _screen_geometry_at(self, x: int, y: int):
@@ -467,7 +479,7 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
 
         def _bubble_rect(self) -> tuple[int, int, int, int]:
             card_width = round(420 * self.bubble_scale)
-            card_height = round(84 * self.bubble_scale)
+            card_height = self._card_height()
             pet_width, _ = self._pet_size()
             pet_center_x = self._pet_offset_x(pet_width) + pet_width // 2
             margin = 14
@@ -601,6 +613,127 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 painter.setBrush(foreground)
                 painter.drawEllipse(center_x - 5, center_y - 5, 10, 10)
 
+        def _card_height(self) -> int:
+            if len(self.tasks) >= 2:
+                rows = min(len(self.tasks), 3)
+                return round((58 + rows * 26) * self.bubble_scale)
+            return round(84 * self.bubble_scale)
+
+        def _draw_card_background(
+            self,
+            painter: QPainter,
+            card_x: int,
+            card_y: int,
+            card_width: int,
+            card_height: int,
+            corner_radius: int,
+            s: float,
+        ) -> None:
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(17, 24, 39, 13))
+            painter.drawRoundedRect(
+                card_x + 1, card_y + round(13 * s), card_width - 2, card_height,
+                corner_radius, corner_radius,
+            )
+            painter.setBrush(QColor(17, 24, 39, 18))
+            painter.drawRoundedRect(
+                card_x, card_y + round(7 * s), card_width, card_height,
+                corner_radius, corner_radius,
+            )
+            painter.setPen(QPen(QColor(218, 221, 226, 205), 1))
+            painter.setBrush(QColor(252, 252, 253, 248))
+            painter.drawRoundedRect(
+                card_x, card_y, card_width, card_height,
+                corner_radius, corner_radius,
+            )
+
+        def _draw_multi_task_card(
+            self,
+            painter: QPainter,
+            card_x: int,
+            card_y: int,
+            card_width: int,
+            card_height: int,
+            s: float,
+        ) -> None:
+            title_font = QFont("Microsoft YaHei UI")
+            title_font.setPointSizeF(max(8.0, 11.0 * s))
+            title_font.setWeight(QFont.Weight.DemiBold)
+            detail_font = QFont("Microsoft YaHei UI")
+            detail_font.setPointSizeF(max(7.0, 9.0 * s))
+            text_x = card_x + round(16 * s)
+            text_width = max(40, card_width - round(32 * s))
+            painter.setFont(title_font)
+            painter.setPen(QColor("#25282D"))
+            title = f"{len(self.tasks)} 个任务进行中"
+            painter.drawText(
+                text_x,
+                card_y + round(10 * s),
+                text_width,
+                max(12, round(22 * s)),
+                Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+                QFontMetrics(title_font).elidedText(title, Qt.TextElideMode.ElideRight, text_width),
+            )
+            painter.setFont(detail_font)
+            for index, task in enumerate(self.tasks[:3]):
+                row_y = card_y + round((36 + index * 24) * s)
+                state = str(task.get("state", "IDLE"))
+                state_label = self.LABELS.get(state, state)
+                label = task.get("project") or task.get("task") or task.get("message") or state_label
+                line = f"{state_label} · {label}"
+                _, foreground = self._status_colors(state)
+                painter.setPen(Qt.PenStyle.NoPen)
+                painter.setBrush(foreground)
+                painter.drawEllipse(text_x, row_y + round(4 * s), round(8 * s), round(8 * s))
+                painter.setPen(QColor("#747981"))
+                painter.drawText(
+                    text_x + round(14 * s),
+                    row_y,
+                    text_width - round(14 * s),
+                    max(12, round(20 * s)),
+                    Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+                    QFontMetrics(detail_font).elidedText(line, Qt.TextElideMode.ElideRight, text_width - round(14 * s)),
+                )
+            if len(self.tasks) > 3:
+                more = f"还有 {len(self.tasks) - 3} 个任务…"
+                painter.setPen(QColor("#9AA0A6"))
+                painter.drawText(
+                    text_x + round(14 * s),
+                    card_y + round((36 + 3 * 24) * s),
+                    text_width,
+                    max(12, round(20 * s)),
+                    Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+                    more,
+                )
+
+        def _notify_alert(self, state: str) -> None:
+            try:
+                QApplication.beep()
+            except Exception:
+                pass
+            self._shake_window()
+
+        def _shake_window(self) -> None:
+            if self.shake_timer is None:
+                self.shake_timer = QTimer(self)
+                self.shake_timer.timeout.connect(self._shake_tick)
+            self.shake_origin = self.pos()
+            self.shake_count = 0
+            self.shake_timer.start(30)
+
+        def _shake_tick(self) -> None:
+            offsets = [(6, 0), (-6, 0), (4, 0), (-4, 0), (2, 0), (-2, 0), (0, 0)]
+            if self.shake_origin is None:
+                self.shake_timer.stop()
+                return
+            if self.shake_count < len(offsets):
+                dx, dy = offsets[self.shake_count]
+                self.move(self.shake_origin.x() + dx, self.shake_origin.y() + dy)
+                self.shake_count += 1
+            else:
+                self.shake_timer.stop()
+                self.move(self.shake_origin)
+
         def paintEvent(self, _event: Any) -> None:
             painter = QPainter(self)
             painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
@@ -608,30 +741,18 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             painter.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform, True)
             card = self._current_card()
             bubble_height = 12
-            if card:
-                title, detail, card_state = card
-                card_x, card_y, card_width, card_height = self._bubble_rect()
-                bubble_height = card_y + card_height + 19
-                s = self.bubble_scale
-                corner_radius = round(30 * s)
-                painter.setPen(Qt.PenStyle.NoPen)
-                painter.setBrush(QColor(17, 24, 39, 13))
-                painter.drawRoundedRect(
-                    card_x + 1, card_y + round(13 * s), card_width - 2, card_height,
-                    corner_radius, corner_radius,
-                )
-                painter.setBrush(QColor(17, 24, 39, 18))
-                painter.drawRoundedRect(
-                    card_x, card_y + round(7 * s), card_width, card_height,
-                    corner_radius, corner_radius,
-                )
-                painter.setPen(QPen(QColor(218, 221, 226, 205), 1))
-                painter.setBrush(QColor(252, 252, 253, 248))
-                painter.drawRoundedRect(
-                    card_x, card_y, card_width, card_height,
-                    corner_radius, corner_radius,
-                )
+            card_x, card_y, card_width, card_height = self._bubble_rect()
+            s = self.bubble_scale
+            corner_radius = round(30 * s)
 
+            if len(self.tasks) >= 2:
+                bubble_height = card_y + card_height + 19
+                self._draw_card_background(painter, card_x, card_y, card_width, card_height, corner_radius, s)
+                self._draw_multi_task_card(painter, card_x, card_y, card_width, card_height, s)
+            elif card:
+                title, detail, card_state = card
+                bubble_height = card_y + card_height + 19
+                self._draw_card_background(painter, card_x, card_y, card_width, card_height, corner_radius, s)
                 icon_center_x = card_x + card_width - round(39 * s)
                 icon_center_y = card_y + card_height // 2
                 painter.save()
@@ -815,6 +936,7 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             reduced_action = menu.addAction("减少动态")
             reduced_action.setCheckable(True)
             reduced_action.setChecked(self.reduced_motion)
+            open_webui_action = menu.addAction("打开 WebUI")
             menu.addSeparator()
             hide_action = menu.addAction("本次隐藏")
             exit_action = menu.addAction("本次关闭")
@@ -838,6 +960,8 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                     self._schedule_micro()
                 self._save_layout()
                 self.update()
+            elif selected == open_webui_action:
+                QDesktopServices.openUrl(QUrl(self.webui_url))
             elif selected == hide_action:
                 self.hide()
             elif selected == exit_action:

--- a/scripts/test-packaged-helper.mjs
+++ b/scripts/test-packaged-helper.mjs
@@ -57,6 +57,15 @@ try {
     message: 'Packaged visual smoke test',
     detail: 'Qt renderer and assets are available',
   })}\n`)
+  child.stdin.write(`${JSON.stringify({
+    protocolVersion: 1,
+    kind: 'tasks',
+    timestamp: Date.now(),
+    tasks: [
+      { sessionId: 'one', state: 'WORKING', project: 'dsh-dafeiyu', task: 'Windows package validation' },
+      { sessionId: 'two', state: 'WAITING', project: 'WSL2 interop', task: 'User confirmation' },
+    ],
+  })}\n`)
   await waitUntil(async () => {
     try {
       return (await stat(snapshot)).size > 1024

--- a/src/companion-reducer.js
+++ b/src/companion-reducer.js
@@ -105,6 +105,7 @@ export class CompanionReducer {
     this.clock = 0
     this.selectedSessionId = undefined
     this.outputSignature = undefined
+    this.tasksSignature = undefined
   }
 
   setIncludeSubagents(value) {
@@ -244,7 +245,7 @@ export class CompanionReducer {
       return this.#render(selection)
     }
     this.#remember(selection)
-    return [createMessage(CompanionMessageKind.PULSE, {
+    return this.#withTasks([createMessage(CompanionMessageKind.PULSE, {
       sessionId: record.id,
       sourceSeq: event.seq,
       state: CompanionState.ERROR,
@@ -256,7 +257,7 @@ export class CompanionReducer {
       message: statusCopy('toolError', event.seq),
       detail: detailFor(record),
       errorCode: event.data.error.code,
-    })]
+    })])
   }
 
   #todo(record, event) {
@@ -275,7 +276,7 @@ export class CompanionReducer {
     record.updatedAt = ++this.clock
     const selection = this.#select()
     if (selection.record.id !== record.id) return this.#render(selection)
-    return [createMessage(CompanionMessageKind.TASK, {
+    return this.#withTasks([createMessage(CompanionMessageKind.TASK, {
       sessionId: record.id,
       sourceSeq: event.seq,
       task: record.task,
@@ -283,7 +284,7 @@ export class CompanionReducer {
       project: record.project,
       message: taskCopy(record.task),
       detail: detailFor(record, '执行阶段'),
-    })]
+    })])
   }
 
   #turnEnd(record, event) {
@@ -332,7 +333,7 @@ export class CompanionReducer {
       return this.#render(selection)
     }
     this.#remember(selection)
-    return [createMessage(CompanionMessageKind.PULSE, {
+    return this.#withTasks([createMessage(CompanionMessageKind.PULSE, {
       sessionId: record.id,
       sourceSeq: event.seq,
       state: CompanionState.SUCCESS,
@@ -344,7 +345,7 @@ export class CompanionReducer {
       phase: 'turn-end',
       message: statusCopy('success', event.seq),
       detail: detailFor(record, '本轮已完成'),
-    })]
+    })])
   }
 
   #record(sessionId) {
@@ -394,18 +395,65 @@ export class CompanionReducer {
   }
 
   #render(selection = this.#select()) {
+    const messages = []
     const signature = this.#signature(selection.record)
-    if (signature === this.outputSignature) return []
-    this.#remember(selection)
-    return [createMessage(CompanionMessageKind.STATE, {
-      sessionId: selection.record.id,
-      state: selection.record.state,
-      ...selection.record.payload,
-      task: selection.record.task,
-      progress: selection.record.progress,
-      project: selection.record.project,
-      detail: detailFor(selection.record),
-    })]
+    if (signature !== this.outputSignature) {
+      this.#remember(selection)
+      messages.push(createMessage(CompanionMessageKind.STATE, {
+        sessionId: selection.record.id,
+        state: selection.record.state,
+        ...selection.record.payload,
+        task: selection.record.task,
+        progress: selection.record.progress,
+        project: selection.record.project,
+        detail: detailFor(selection.record),
+      }))
+    }
+    messages.push(...this.#taskMessages())
+    return messages
+  }
+
+  #taskMessages() {
+    const tasks = this.#activeTaskList()
+    if (tasks.length < 2) {
+      if (this.tasksSignature !== undefined) {
+        this.tasksSignature = undefined
+        return [createMessage(CompanionMessageKind.TASKS, { tasks: [] })]
+      }
+      return []
+    }
+    const signature = tasks.map((task) => [
+      task.sessionId,
+      task.state,
+      task.project ?? '',
+      task.task ?? '',
+      task.message ?? '',
+      task.detail ?? '',
+    ].join('|')).join('~')
+    if (signature === this.tasksSignature) return []
+    this.tasksSignature = signature
+    return [createMessage(CompanionMessageKind.TASKS, { tasks })]
+  }
+
+  #activeTaskList() {
+    return [...this.sessions.values()]
+      .filter((record) => record.state !== CompanionState.IDLE && record.state !== CompanionState.DISCONNECTED)
+      .sort((left, right) => {
+        const priority = (statePriority[right.state] ?? 0) - (statePriority[left.state] ?? 0)
+        return priority || right.updatedAt - left.updatedAt || left.id.localeCompare(right.id)
+      })
+      .map((record) => ({
+        sessionId: record.id,
+        state: record.state,
+        project: record.project,
+        task: record.task,
+        message: record.payload.message,
+        detail: detailFor(record),
+      }))
+  }
+
+  #withTasks(messages) {
+    return [...messages, ...this.#taskMessages()]
   }
 
   #remember(selection) {

--- a/src/helper-process.js
+++ b/src/helper-process.js
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
@@ -13,8 +13,25 @@ const here = dirname(fileURLToPath(import.meta.url))
 const defaultHelperPath = resolve(here, '..', 'runtime', 'helper.py')
 const bundledHelperPath = resolve(here, '..', 'runtime', 'bin', 'win32-x64', 'dsh-dafeiyu-helper.exe')
 
-function defaultCommand() {
-  if (process.platform === 'win32' && existsSync(bundledHelperPath)) return bundledHelperPath
+function isWsl() {
+  if (process.platform !== 'linux') return false
+  try {
+    return readFileSync('/proc/sys/fs/binfmt_misc/WSLInterop', 'utf8').includes('enabled')
+  } catch {
+    try {
+      return /microsoft/i.test(readFileSync('/proc/version', 'utf8'))
+    } catch {
+      return false
+    }
+  }
+}
+
+function shouldUseBundledHelper() {
+  return (process.platform === 'win32' || isWsl()) && existsSync(bundledHelperPath)
+}
+
+function defaultCommand(headless = false) {
+  if (shouldUseBundledHelper() && !(headless && isWsl())) return bundledHelperPath
   return process.env.DSH_DAFEIYU_PYTHON || (process.platform === 'win32' ? 'py' : 'python3')
 }
 
@@ -45,11 +62,11 @@ export class HelperProcess {
 
   start() {
     if (this.child || this.stopping || this.restartSuppressed) return this.child
-    const command = this.options.command || defaultCommand()
+    const headless = this.options.headless ?? process.env.DSH_DAFEIYU_HEADLESS === '1'
+    const command = this.options.command || defaultCommand(headless)
     const helperPath = this.options.helperPath || defaultHelperPath
     const args = this.options.args || defaultArgs(command, helperPath)
     const extraArgs = []
-    const headless = this.options.headless ?? process.env.DSH_DAFEIYU_HEADLESS === '1'
     const eventLog = this.options.eventLog || process.env.DSH_DAFEIYU_EVENT_LOG
     const snapshot = this.options.snapshot || process.env.DSH_DAFEIYU_SNAPSHOT
     if (headless) extraArgs.push('--headless')
@@ -99,7 +116,7 @@ export class HelperProcess {
     const line = encodeMessage(message)
     if (!this.child || !this.spawned || !this.child.stdin.writable || this.child.stdin.destroyed) {
       if (!this.hasEverSpawned
-        || ![CompanionMessageKind.HELLO, CompanionMessageKind.STATE, CompanionMessageKind.TASK, CompanionMessageKind.PULSE, CompanionMessageKind.CONFIG].includes(message.kind)) {
+        || ![CompanionMessageKind.HELLO, CompanionMessageKind.STATE, CompanionMessageKind.TASK, CompanionMessageKind.TASKS, CompanionMessageKind.PULSE, CompanionMessageKind.CONFIG].includes(message.kind)) {
         this.queue.push(line)
       }
       return
@@ -129,6 +146,7 @@ export class HelperProcess {
     if (message.kind === CompanionMessageKind.HELLO) this.snapshot.set('hello', encodeMessage(message))
     if (message.kind === CompanionMessageKind.STATE) this.snapshot.set('state', encodeMessage(message))
     if (message.kind === CompanionMessageKind.TASK) this.snapshot.set('task', encodeMessage(message))
+    if (message.kind === CompanionMessageKind.TASKS) this.snapshot.set('tasks', encodeMessage(message))
     if (message.kind === CompanionMessageKind.CONFIG) this.snapshot.set('config', encodeMessage(message))
   }
 
@@ -222,4 +240,4 @@ export class HelperProcess {
   }
 }
 
-export { bundledHelperPath, defaultHelperPath }
+export { bundledHelperPath, defaultHelperPath, defaultArgs, defaultCommand, isWsl, shouldUseBundledHelper }

--- a/src/helper-process.js
+++ b/src/helper-process.js
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
@@ -30,9 +30,50 @@ function shouldUseBundledHelper() {
   return (process.platform === 'win32' || isWsl()) && existsSync(bundledHelperPath)
 }
 
+function toWindowsPath(path) {
+  return execFileSync('wslpath', ['-w', path], { encoding: 'utf8' }).trim()
+}
+
+function resolveHelperLaunch({
+  platform,
+  isWslEnv,
+  bundledPath,
+  helperPath,
+  pythonEnv,
+  headless = false,
+  fileExists = existsSync,
+  windowsPath = toWindowsPath,
+}) {
+  if (platform === 'win32' && fileExists(bundledPath)) {
+    return { command: bundledPath, args: [] }
+  }
+  if (platform === 'linux' && isWslEnv && !headless && fileExists(bundledPath)) {
+    // npm archives created on Windows store ordinary files as 0644. Launching
+    // the EXE directly from WSL can therefore fail with EACCES. cmd.exe opens
+    // the Windows path without relying on the Linux executable bit and keeps
+    // stdin/stdout attached for the companion protocol.
+    return {
+      command: 'cmd.exe',
+      args: ['/d', '/c', windowsPath(bundledPath)],
+    }
+  }
+  const command = pythonEnv || (platform === 'win32' ? 'py' : 'python3')
+  return { command, args: defaultArgs(command, helperPath) }
+}
+
+function defaultLaunch(headless = false) {
+  return resolveHelperLaunch({
+    platform: process.platform,
+    isWslEnv: isWsl(),
+    bundledPath: bundledHelperPath,
+    helperPath: defaultHelperPath,
+    pythonEnv: process.env.DSH_DAFEIYU_PYTHON,
+    headless,
+  })
+}
+
 function defaultCommand(headless = false) {
-  if (shouldUseBundledHelper() && !(headless && isWsl())) return bundledHelperPath
-  return process.env.DSH_DAFEIYU_PYTHON || (process.platform === 'win32' ? 'py' : 'python3')
+  return defaultLaunch(headless).command
 }
 
 function defaultArgs(command, helperPath) {
@@ -63,9 +104,12 @@ export class HelperProcess {
   start() {
     if (this.child || this.stopping || this.restartSuppressed) return this.child
     const headless = this.options.headless ?? process.env.DSH_DAFEIYU_HEADLESS === '1'
-    const command = this.options.command || defaultCommand(headless)
     const helperPath = this.options.helperPath || defaultHelperPath
-    const args = this.options.args || defaultArgs(command, helperPath)
+    const launch = this.options.command
+      ? { command: this.options.command, args: defaultArgs(this.options.command, helperPath) }
+      : defaultLaunch(headless)
+    const command = launch.command
+    const args = this.options.args || launch.args
     const extraArgs = []
     const eventLog = this.options.eventLog || process.env.DSH_DAFEIYU_EVENT_LOG
     const snapshot = this.options.snapshot || process.env.DSH_DAFEIYU_SNAPSHOT
@@ -240,4 +284,14 @@ export class HelperProcess {
   }
 }
 
-export { bundledHelperPath, defaultHelperPath, defaultArgs, defaultCommand, isWsl, shouldUseBundledHelper }
+export {
+  bundledHelperPath,
+  defaultHelperPath,
+  defaultArgs,
+  defaultCommand,
+  defaultLaunch,
+  isWsl,
+  resolveHelperLaunch,
+  shouldUseBundledHelper,
+  toWindowsPath,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -167,6 +167,7 @@ function mount(ctx, config = {}, eventCtx = ctx) {
         DSH_DAFEIYU_BUBBLE_SCALE: String(resolved.bubbleScale ?? defaults.bubbleScale),
         DSH_DAFEIYU_ACTIVITY_LEVEL: String(resolved.activityLevel ?? defaults.activityLevel),
         DSH_DAFEIYU_REDUCED_MOTION: resolved.reducedMotion === true ? '1' : '0',
+        DSH_DAFEIYU_WEBUI_URL: String(config.webuiUrl ?? process.env.DSH_DAFEIYU_WEBUI_URL ?? 'http://127.0.0.1:3080/'),
       },
     }, logger)
     reducer = new CompanionReducer({ includeSubagents: resolved.includeSubagents === true })

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -16,6 +16,7 @@ export const CompanionMessageKind = Object.freeze({
   STATE: 'state',
   PULSE: 'pulse',
   TASK: 'task',
+  TASKS: 'tasks',
   CONFIG: 'config',
   PING: 'ping',
   PONG: 'pong',

--- a/test/helper-command.test.js
+++ b/test/helper-command.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { resolveHelperLaunch } from '../src/helper-process.js'
+
+const bundledPath = '/package/runtime/bin/win32-x64/dsh-dafeiyu-helper.exe'
+const helperPath = '/package/runtime/helper.py'
+
+function resolve(overrides = {}) {
+  return resolveHelperLaunch({
+    platform: 'linux',
+    isWslEnv: false,
+    bundledPath,
+    helperPath,
+    fileExists: () => true,
+    windowsPath: () => 'C:\\package\\runtime\\bin\\win32-x64\\dsh-dafeiyu-helper.exe',
+    ...overrides,
+  })
+}
+
+test('native Windows launches the bundled x64 helper directly', () => {
+  assert.deepEqual(resolve({ platform: 'win32' }), { command: bundledPath, args: [] })
+})
+
+test('WSL visual mode uses cmd.exe so npm file modes cannot block the helper', () => {
+  assert.deepEqual(resolve({ isWslEnv: true }), {
+    command: 'cmd.exe',
+    args: ['/d', '/c', 'C:\\package\\runtime\\bin\\win32-x64\\dsh-dafeiyu-helper.exe'],
+  })
+})
+
+test('WSL headless mode stays on Linux Python for Linux event-log paths', () => {
+  assert.deepEqual(resolve({ isWslEnv: true, headless: true }), {
+    command: 'python3',
+    args: [helperPath],
+  })
+})
+
+test('ordinary Linux does not attempt Windows interop', () => {
+  assert.deepEqual(resolve(), { command: 'python3', args: [helperPath] })
+})
+
+test('missing bundled helper falls back to the configured Python', () => {
+  assert.deepEqual(resolve({
+    isWslEnv: true,
+    fileExists: () => false,
+    pythonEnv: '/opt/dsh/python',
+  }), {
+    command: '/opt/dsh/python',
+    args: [helperPath],
+  })
+})

--- a/test/helper-lifecycle.test.js
+++ b/test/helper-lifecycle.test.js
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
-import { HelperProcess } from '../src/helper-process.js'
+import { HelperProcess, defaultCommand, isWsl, shouldUseBundledHelper } from '../src/helper-process.js'
 import { CompanionMessageKind, CompanionState, createMessage } from '../src/protocol.js'
 
 async function waitFor(predicate, timeoutMs = 3000) {
@@ -14,6 +14,13 @@ async function waitFor(predicate, timeoutMs = 3000) {
   }
   throw new Error('timed out waiting for helper condition')
 }
+
+test('helper process exposes WSL detection helpers without throwing', () => {
+  assert.equal(typeof isWsl(), 'boolean')
+  assert.equal(typeof shouldUseBundledHelper(), 'boolean')
+  assert.equal(typeof defaultCommand(), 'string')
+  assert.equal(typeof defaultCommand(true), 'string')
+})
 
 test('helper consumes events and exits when the plugin stops', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'dsh-dafeiyu-test-'))

--- a/test/protocol.test.js
+++ b/test/protocol.test.js
@@ -24,6 +24,17 @@ test('protocol accepts the helper readiness handshake', () => {
   assert.equal(assertCompanionMessage(message).kind, 'ready')
 })
 
+test('protocol creates and encodes a multi-task message', () => {
+  const message = createMessage(CompanionMessageKind.TASKS, {
+    tasks: [
+      { sessionId: 'one', state: CompanionState.WORKING, project: 'demo', task: 'write code' },
+      { sessionId: 'two', state: CompanionState.WAITING, project: 'demo', task: 'confirm' },
+    ],
+  })
+  assert.equal(assertCompanionMessage(message), message)
+  assert.deepEqual(JSON.parse(encodeMessage(message)), message)
+})
+
 test('protocol creates and encodes a live config message', () => {
   const message = createMessage(CompanionMessageKind.CONFIG, {
     scale: 0.9,

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -167,15 +167,36 @@ test('multi-session selection follows attention priority instead of latest-event
   }, 2))
   assert.equal(blocked.state, CompanionState.WAITING)
 
-  assert.deepEqual(reducer.handle(working, event('turn/start', { turn: 1 }, 1)), [])
-  assert.deepEqual(reducer.handle(working, event('tool/call', {
+  const [tasksAfterStart] = reducer.handle(working, event('turn/start', { turn: 1 }, 1))
+  assert.equal(tasksAfterStart.kind, CompanionMessageKind.TASKS)
+  assert.equal(tasksAfterStart.tasks.length, 2)
+  assert.equal(tasksAfterStart.tasks[0].sessionId, 'waiting-session')
+  const [tasksAfterTool] = reducer.handle(working, event('tool/call', {
     callId: 'call-working',
     name: 'shell_command',
-  }, 2)), [])
+  }, 2))
+  assert.equal(tasksAfterTool.kind, CompanionMessageKind.TASKS)
+  assert.equal(tasksAfterTool.tasks[0].state, CompanionState.WAITING)
+  assert.equal(tasksAfterTool.tasks[1].state, CompanionState.WORKING)
 
   const [revealed] = reducer.disposeSession(waiting)
   assert.equal(revealed.sessionId, 'working-session')
   assert.equal(revealed.state, CompanionState.WORKING)
+})
+
+test('multi-task list is cleared when only one active task remains', () => {
+  const reducer = new CompanionReducer()
+  const first = { header: { id: 'first' } }
+  const second = { header: { id: 'second' } }
+  reducer.handle(first, event('turn/start', { turn: 1 }, 1))
+  reducer.handle(second, event('turn/start', { turn: 1 }, 1))
+  const messages = reducer.handle(first, event('turn/end', {
+    turn: 1,
+    reason: { kind: 'completed' },
+  }, 2))
+  assert.equal(messages.some((message) => message.kind === CompanionMessageKind.TASKS), true)
+  const clearTasks = messages.find((message) => message.kind === CompanionMessageKind.TASKS)
+  assert.deepEqual(clearTasks.tasks, [])
 })
 
 test('completion pulse resumes the highest-priority remaining session', () => {
@@ -208,7 +229,10 @@ test('failed turns remain visible until that session changes or is disposed', ()
     reason: { kind: 'error' },
   }, 2))
   assert.equal(failure.state, CompanionState.ERROR)
-  assert.deepEqual(reducer.handle(newer, event('turn/start', { turn: 1 }, 1)), [])
+  const [tasksAfterNewer] = reducer.handle(newer, event('turn/start', { turn: 1 }, 1))
+  assert.equal(tasksAfterNewer.kind, CompanionMessageKind.TASKS)
+  assert.equal(tasksAfterNewer.tasks.length, 2)
+  assert.equal(tasksAfterNewer.tasks[0].state, CompanionState.ERROR)
 })
 
 test('todo events preserve real project and progress context for the status card', () => {


### PR DESCRIPTION
## Summary

Implements WSL2 support from PR #8 and the desktop interaction enhancements requested in Issue #12.

### WSL2 support

- Allow npm installation on Linux while retaining the x64 CPU requirement.
- Detect WSL2 and launch the bundled Windows Helper through `cmd.exe`.
- Avoid any dependency on the npm archive's Linux executable bit; no manual `chmod`, Python, or PySide6 setup is required in WSL.
- Keep headless diagnostics on Linux Python so Linux event-log paths remain usable.
- Do not treat ordinary Linux, remote Linux, or containers as Windows-interoperable environments.

### Issue #12

- Add a right-click **打开 WebUI** action.
- Add completion/error feedback with a beep and brief window shake.
- Add a multi-task status card and a `TASKS` protocol message.
- Snapshot and replay the active task list after Helper restart.

### Release

- Version: `0.1.0-alpha.10`
- Update command: `dsh plugin --profile web update dsh-dafeiyu@alpha`

### Validation

- `npm test`: 40 passed
- Python unit tests: 10 passed
- Windows x64 Helper rebuilt with PyInstaller/PySide6
- Packaged Qt visual smoke test rendered the multi-task card
- WSL2 visual interop test passed with the Helper copied into the Linux filesystem and forced to mode `0644`: ready handshake, 160,818-byte Qt snapshot, and clean shutdown
- `npm pack` produced a 55.5 MB alpha.10 archive containing the 50.9 MB visual Helper
- Package metadata retains `cpu: ["x64"]` and has no npm `os` restriction

Addresses #8.
Closes #12.