### PR TITLE
feat: integrate and verify native macOS Helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           app=runtime/bin/darwin/dsh-dafeiyu-helper.app
           binary="$app/Contents/MacOS/dsh-dafeiyu-helper"
-          lipo -verify_arch arm64 x86_64 "$binary"
+          lipo "$binary" -verify_arch arm64 x86_64
           codesign --verify --deep --strict --verbose=2 "$app"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist")" = "$(node -p "require('./package.json').version")"
 
@@ -139,6 +139,6 @@ jobs:
           app=.build/package-check/package/runtime/bin/darwin/dsh-dafeiyu-helper.app
           binary="$app/Contents/MacOS/dsh-dafeiyu-helper"
           test -x "$binary"
-          lipo -verify_arch arm64 x86_64 "$binary"
+          lipo "$binary" -verify_arch arm64 x86_64
           codesign --verify --deep --strict --verbose=2 "$app"
           node scripts/test-packaged-helper.mjs --executable "$binary"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,54 @@ jobs:
           test -x .build/package-check/package/runtime/bin/linux-x64/dsh-dafeiyu-helper
           xvfb-run --auto-servernum node scripts/test-packaged-helper.mjs \
             --executable .build/package-check/package/runtime/bin/linux-x64/dsh-dafeiyu-helper
+
+  macos-helper:
+    name: Build and smoke-test macOS universal Helper
+    runs-on: macos-15
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Install pnpm
+        run: npm install --global pnpm@11.21.0
+
+      - name: Install JavaScript dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run JavaScript tests
+        run: npm test
+
+      - name: Run Python tests
+        run: python3 -m unittest discover -s runtime/tests -t .
+
+      - name: Build and visually smoke-test macOS Helper
+        run: |
+          npm run build:helper:darwin
+          node scripts/test-packaged-helper.mjs
+
+      - name: Verify universal architecture and ad-hoc signature
+        run: |
+          app=runtime/bin/darwin/dsh-dafeiyu-helper.app
+          binary="$app/Contents/MacOS/dsh-dafeiyu-helper"
+          lipo -verify_arch arm64 x86_64 "$binary"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist")" = "$(node -p "require('./package.json').version")"
+
+      - name: Verify macOS Helper survives npm packaging
+        run: |
+          archive=$(npm pack --silent)
+          mkdir -p .build/package-check
+          tar -xzf "$archive" -C .build/package-check
+          app=.build/package-check/package/runtime/bin/darwin/dsh-dafeiyu-helper.app
+          binary="$app/Contents/MacOS/dsh-dafeiyu-helper"
+          test -x "$binary"
+          lipo -verify_arch arm64 x86_64 "$binary"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          node scripts/test-packaged-helper.mjs --executable "$binary"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,11 +119,48 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  build-macos-helper:
+    name: Build and verify macOS universal Helper
+    runs-on: macos-15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Build and smoke-test macOS Helper
+        run: |
+          npm run build:helper:darwin
+          node scripts/test-packaged-helper.mjs
+
+      - name: Verify universal architecture and ad-hoc signature
+        run: |
+          app=runtime/bin/darwin/dsh-dafeiyu-helper.app
+          binary="$app/Contents/MacOS/dsh-dafeiyu-helper"
+          lipo -verify_arch arm64 x86_64 "$binary"
+          codesign --verify --deep --strict --verbose=2 "$app"
+
+      - name: Upload macOS Helper
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-helper
+          path: runtime/bin/darwin
+          if-no-files-found: error
+          retention-days: 14
+
   assemble-package:
     name: Assemble and verify cross-platform package
     needs:
       - build-windows-helper
       - build-linux-helper
+      - build-macos-helper
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -159,16 +196,24 @@ jobs:
           name: linux-helper
           path: runtime/bin/linux-x64
 
+      - name: Download macOS Helper
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-helper
+          path: runtime/bin/darwin
+
       - name: Create and verify npm archive
         shell: bash
         run: |
           set -euo pipefail
           chmod 0755 runtime/bin/linux-x64/dsh-dafeiyu-helper
+          chmod 0755 runtime/bin/darwin/dsh-dafeiyu-helper.app/Contents/MacOS/dsh-dafeiyu-helper
           archive=$(npm pack --silent)
           mkdir -p .build/package-check
           tar -xzf "$archive" -C .build/package-check
           test -f .build/package-check/package/runtime/bin/win32-x64/dsh-dafeiyu-helper.exe
           test -x .build/package-check/package/runtime/bin/linux-x64/dsh-dafeiyu-helper
+          test -x .build/package-check/package/runtime/bin/darwin/dsh-dafeiyu-helper.app/Contents/MacOS/dsh-dafeiyu-helper
           xvfb-run --auto-servernum node scripts/test-packaged-helper.mjs \
             --executable .build/package-check/package/runtime/bin/linux-x64/dsh-dafeiyu-helper
 
@@ -180,9 +225,45 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  verify-macos-package:
+    name: Verify final npm archive on macOS
+    needs: assemble-package
+    runs-on: macos-15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Download verified cross-platform package
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-package
+          path: dist
+
+      - name: Extract and smoke-test macOS Helper
+        run: |
+          mkdir -p .build/package-check
+          tar -xzf dist/dsh-dafeiyu-*.tgz -C .build/package-check
+          app=.build/package-check/package/runtime/bin/darwin/dsh-dafeiyu-helper.app
+          binary="$app/Contents/MacOS/dsh-dafeiyu-helper"
+          test -x "$binary"
+          lipo -verify_arch arm64 x86_64 "$binary"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          node scripts/test-packaged-helper.mjs --executable "$binary"
+
   publish:
     name: Publish with npm trusted publishing
-    needs: assemble-package
+    needs:
+      - assemble-package
+      - verify-macos-package
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,7 +144,7 @@ jobs:
         run: |
           app=runtime/bin/darwin/dsh-dafeiyu-helper.app
           binary="$app/Contents/MacOS/dsh-dafeiyu-helper"
-          lipo -verify_arch arm64 x86_64 "$binary"
+          lipo "$binary" -verify_arch arm64 x86_64
           codesign --verify --deep --strict --verbose=2 "$app"
 
       - name: Upload macOS Helper
@@ -255,7 +255,7 @@ jobs:
           app=.build/package-check/package/runtime/bin/darwin/dsh-dafeiyu-helper.app
           binary="$app/Contents/MacOS/dsh-dafeiyu-helper"
           test -x "$binary"
-          lipo -verify_arch arm64 x86_64 "$binary"
+          lipo "$binary" -verify_arch arm64 x86_64
           codesign --verify --deep --strict --verbose=2 "$app"
           node scripts/test-packaged-helper.mjs --executable "$binary"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Linux x64 desktop support with a bundled, Python-free Helper, XDG layout persistence, and X11/Wayland platform selection.
 - Linux Helper build, visual smoke test, and final npm-archive validation in CI and the trusted release workflow.
+- Native macOS Helper built with Swift and AppKit as a universal arm64/x86_64 app for macOS 12+, with no Python runtime requirement.
+- Native macOS build, AppKit screenshot/lifecycle smoke tests, universal-architecture and code-signature checks, plus validation of the final assembled npm archive on a macOS runner.
+
+### Changed
+
+- Removed the npm x64-only installation restriction so Apple Silicon Macs can install the universal package.
 
 ## 0.1.3
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ stateDiagram-v2
 ## 系统要求
 
 - Windows 10/11 x64，或 WSL2（通过 Windows interop 运行桌面 Helper）
-- macOS 12.0+（Apple Silicon 或 Intel）——发布包内置原生 Helper，
-  无需安装 Python / PySide6
+- macOS 12.0+（Apple Silicon 或 Intel）——下个发布包将内置原生 Helper，
+  无需安装 Python / PySide6（当前 npm 0.1.3 尚未包含）
 - 已安装并能正常运行的 DeepSeek Harness WebUI
 - DSH CLI 中可以使用 `plugin --profile web` 命令
 - npm 上的稳定版 `dsh-dafeiyu`（或抢先测试的 `dsh-dafeiyu@alpha`），或 GitHub Release 中的 `.tgz` 安装包
@@ -130,6 +130,9 @@ dsh plugin --profile web add dsh-dafeiyu
 远程 Linux 和容器不是本版本的桌面显示目标。
 
 ### macOS 用户（Apple Silicon / Intel，macOS 12.0+）
+
+> 发布状态：原生 macOS Helper 当前位于 `main` 的 **Unreleased**；已经发布的
+> npm `latest` 0.1.3 尚不包含它。下面的普通用户安装命令从下一版本发布后生效。
 
 macOS 的安装方式与 Windows 相同，只是换成「终端」和 macOS 路径。发布包
 内置原生 Helper，**不需要安装 Python、PySide6 或 Xcode**。

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ stateDiagram-v2
 ## 系统要求
 
 - Windows 10/11 x64，或 WSL2（通过 Windows interop 运行桌面 Helper）
+- macOS 12.0+（Apple Silicon 或 Intel）——发布包内置原生 Helper，
+  无需安装 Python / PySide6
 - 已安装并能正常运行的 DeepSeek Harness WebUI
 - DSH CLI 中可以使用 `plugin --profile web` 命令
 - npm 上的稳定版 `dsh-dafeiyu`（或抢先测试的 `dsh-dafeiyu@alpha`），或 GitHub Release 中的 `.tgz` 安装包
@@ -293,6 +295,39 @@ DSH 后会恢复。若想永久关闭，请在 DSH 设置中取消“启用大�
 - 不监听键盘输入或其他应用行为
 - 不新开网络端口；设置卡复用 DSH 的本地 Web 服务
 - 默认只跟随最近活跃的顶层 DSH Session
+
+## macOS 原生适配（AI 辅助生成）
+
+> **说明**：本仓库的 macOS 原生 Helper（`runtime/bin/darwin/dsh-dafeiyu-helper.app`）
+> 及 `native/macos/` 下的 Swift 源码由 **AI 辅助生成**，经人工 review 与调试后合入，
+> 用于替代原 Qt/PySide6 与 PyObjC 原型在 macOS 上不稳定、易崩溃的问题。
+
+### 重做了哪些地方
+
+- **运行时重写**：Qt/PySide6 桌面窗口（`runtime/helper.py` 的可视路径）与
+  PyObjC 原生窗口原型，重写为 **Swift + 纯 AppKit** 原生实现，不再依赖
+  Python、PySide6、PyObjC 或 anaconda 环境。
+- **动画内核移植**：`runtime/animation_model.py` 的纯逻辑（clips、pulse、
+  overlay、idle 微动作、crossfade、程序化 motion）逐行移植为 Swift，行为与
+  Windows/Qt 版一致。
+- **全屏置顶**：使用 Apple 官方窗口能力（`canJoinAllSpaces` +
+  `fullScreenAuxiliary` + `.floating` 层级），每 2 秒重新断言层级，全屏 App
+  下依然保持在前端。
+- **权限处理**：通知走 `UNUserNotificationCenter`（SUCCESS/ERROR 提示，
+  被拒时回退 beep + 抖动）；辅助功能走 `AXIsProcessTrustedWithOptions`，
+  右键菜单可直达系统设置。
+- **稳定性修复**：helper 的 stdin/stdout/stderr 增加 EPIPE 兜底，helper
+  崩溃只重启自身，不再拖垮 dsh 服务器。
+- **渲染与交互修复**：修复 flipped 视图下图片倒置；拖拽改为绝对坐标 1:1
+  跟手；拖拽时人物与气泡位置同步。
+- **布局迁移**：首次启动自动把旧 Qt 版 top-left 坐标迁移到 AppKit
+  bottom-left 坐标，继续读写同一个 `layout.json`。
+
+### 兼容性
+
+- **架构**：Universal binary（Apple Silicon arm64 + Intel x86_64）
+- **系统**：macOS 12.0+
+- 构建与安装说明见 [native/macos/README.md](native/macos/README.md)
 
 ## 开发与测试
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,38 @@ dsh plugin --profile web add dsh-dafeiyu
 安装 Python 或 PySide6。当前支持范围是 Windows x64 上的 WSL2；普通 Linux、
 远程 Linux 和容器不是本版本的桌面显示目标。
 
+### macOS 用户（Apple Silicon / Intel，macOS 12.0+）
+
+macOS 的安装方式与 Windows 相同，只是换成「终端」和 macOS 路径。发布包
+内置原生 Helper，**不需要安装 Python、PySide6 或 Xcode**。
+
+在「终端」中进入你的 DSH 安装目录（例如 `~/deepseek-harness`）：
+
+```bash
+cd ~/deepseek-harness
+```
+
+然后从 npm 安装稳定版：
+
+```bash
+pnpm exec dsh plugin --profile web add dsh-dafeiyu
+```
+
+如果系统已经能直接使用全局 `dsh` 命令：
+
+```bash
+dsh plugin --profile web add dsh-dafeiyu
+```
+
+也可以从 [GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases)
+下载 `dsh-dafeiyu-<version>.tgz`（不要解压），然后安装：
+
+```bash
+pnpm exec dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
+```
+
+装完照常启动 DSH WebUI，大肥鱼会由 DSH 自动拉起；不要手动打开 Helper。
+
 ### 3. GitHub Release 备用安装方式
 
 进入 [GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases)，下载最新的：

--- a/README_EN.md
+++ b/README_EN.md
@@ -86,8 +86,8 @@ When multiple tasks are active, the status bubble lists them at the same time.
 ## Requirements
 
 - Windows 10/11 x64, or WSL2 (runs the desktop Helper through Windows interop)
-- macOS 12.0+ (Apple Silicon or Intel) — the native Helper is bundled in the
-  release, no Python / PySide6 required
+- macOS 12.0+ (Apple Silicon or Intel) — the next release will bundle the
+  native Helper with no Python / PySide6 requirement (npm 0.1.3 does not yet)
 - A working DeepSeek Harness WebUI installation
 - A DSH CLI that supports `plugin --profile web`
 - the stable `dsh-dafeiyu` from npm (or `dsh-dafeiyu@alpha` to try prereleases early), or a `.tgz` archive from GitHub Releases
@@ -133,6 +133,10 @@ PySide6 installation is required inside WSL. The current target is WSL2 on Windo
 not ordinary Linux, remote Linux, or containers.
 
 ### macOS users (Apple Silicon / Intel, macOS 12.0+)
+
+> Release status: the native macOS Helper is currently **Unreleased** on
+> `main`; npm `latest` 0.1.3 does not contain it. The regular-user install
+> commands below apply after the next release is published.
 
 Installation on macOS is the same as Windows, just in the Terminal with macOS
 paths. The release bundle ships a native Helper — **no Python, PySide6 or Xcode

--- a/README_EN.md
+++ b/README_EN.md
@@ -86,6 +86,8 @@ When multiple tasks are active, the status bubble lists them at the same time.
 ## Requirements
 
 - Windows 10/11 x64, or WSL2 (runs the desktop Helper through Windows interop)
+- macOS 12.0+ (Apple Silicon or Intel) — the native Helper is bundled in the
+  release, no Python / PySide6 required
 - A working DeepSeek Harness WebUI installation
 - A DSH CLI that supports `plugin --profile web`
 - the stable `dsh-dafeiyu` from npm (or `dsh-dafeiyu@alpha` to try prereleases early), or a `.tgz` archive from GitHub Releases
@@ -296,6 +298,45 @@ DSH to bring it back. To disable it permanently, turn off “Enable BigFish” i
 - Does not monitor keyboard input or other app activity
 - Does not open a new network port; the settings card reuses DSH's local Web service
 - Follows the most recently active top-level DSH session by default
+
+## Native macOS port (AI-assisted)
+
+> **Note**: the native macOS helper (`runtime/bin/darwin/dsh-dafeiyu-helper.app`)
+> and the Swift sources under `native/macos/` were **generated with AI
+> assistance**, reviewed and debugged by a human before being merged. They
+> replace the original Qt/PySide6 and PyObjC prototypes, which were unstable
+> and crash-prone on macOS.
+
+What was redone:
+
+- **Runtime rewrite**: the Qt/PySide6 window (the visual path of
+  `runtime/helper.py`) and the PyObjC native-window prototype were rewritten as
+  a **pure Swift + AppKit** implementation. Python, PySide6, PyObjC and
+  conda environments are no longer required.
+- **Animation engine port**: the pure logic of `runtime/animation_model.py`
+  (clips, pulse, overlay, idle micro-motions, crossfade, procedural motion)
+  was ported line-by-line to Swift with behavior parity with the Windows/Qt
+  version.
+- **Above-fullscreen window**: Apple's official window capabilities
+  (`canJoinAllSpaces` + `fullScreenAuxiliary` + `.floating` level), re-asserted
+  every 2 seconds so the pet stays in front of full-screen apps.
+- **Permissions**: notifications via `UNUserNotificationCenter` (SUCCESS/ERROR
+  alerts, falling back to beep + shake when denied); Accessibility via
+  `AXIsProcessTrustedWithOptions` with a System Settings deep link in the
+  context menu.
+- **Stability fixes**: EPIPE guards on the helper's stdin/stdout/stderr so a
+  helper crash only restarts the helper itself, never the dsh server.
+- **Rendering/interaction fixes**: fixed the upside-down image in the flipped
+  view, made dragging track the cursor 1:1 with absolute coordinates, and kept
+  the character and the status bubble in sync while dragging.
+- **Layout migration**: on first launch the old Qt top-left coordinates are
+  migrated to AppKit bottom-left, still reading/writing the same `layout.json`.
+
+Compatibility:
+
+- **Architecture**: Universal binary (Apple Silicon arm64 + Intel x86_64)
+- **System**: macOS 12.0+
+- Build and install instructions: [native/macos/README.md](native/macos/README.md)
 
 ## Development and tests
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -132,6 +132,42 @@ launches the bundled Windows Helper through `cmd.exe`; no manual `chmod`, Python
 PySide6 installation is required inside WSL. The current target is WSL2 on Windows x64,
 not ordinary Linux, remote Linux, or containers.
 
+### macOS users (Apple Silicon / Intel, macOS 12.0+)
+
+Installation on macOS is the same as Windows, just in the Terminal with macOS
+paths. The release bundle ships a native Helper — **no Python, PySide6 or Xcode
+required**.
+
+In Terminal, `cd` into your DSH installation directory (for example
+`~/deepseek-harness`):
+
+```bash
+cd ~/deepseek-harness
+```
+
+Install the current stable release from npm:
+
+```bash
+pnpm exec dsh plugin --profile web add dsh-dafeiyu
+```
+
+If `dsh` is already available globally:
+
+```bash
+dsh plugin --profile web add dsh-dafeiyu
+```
+
+Alternatively, download `dsh-dafeiyu-<version>.tgz` from
+[GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases) (do not
+extract it) and install it:
+
+```bash
+pnpm exec dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
+```
+
+Then launch DSH WebUI normally; BigFish is started automatically. Do not start
+the Helper yourself.
+
 ### 3. GitHub Release fallback
 
 Open [GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases) and download:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,11 +1,12 @@
 # Publishing releases
 
 The repository publishes one cross-platform package through GitHub Actions and npm trusted
-publishing. Windows and Linux x64 Helpers are built and visually smoke-tested on their native
-GitHub-hosted runners. A Linux assembly job then combines both artifacts, checks their final npm
-archive paths and executable modes, and smoke-tests the Linux Helper from the extracted `.tgz`.
-That exact archive is published using short-lived OIDC credentials. No npm password or long-lived
-publish token is stored in GitHub, Windows, or WSL.
+publishing. Windows, Linux x64, and macOS universal Helpers are built and visually smoke-tested on
+their native GitHub-hosted runners. A Linux assembly job combines all three artifacts, checks their
+final npm archive paths and executable modes, and smoke-tests the Linux Helper from the extracted
+`.tgz`. A macOS runner then verifies both Mach-O architectures, the ad-hoc signature, AppKit
+rendering, and stdin lifecycle from that exact final archive before OIDC publishing. No npm
+password or long-lived publish token is stored in GitHub, Windows, or WSL.
 
 ## One-time npm setup
 

--- a/native/macos/Info.plist
+++ b/native/macos/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleVersion</key>
-	<string>0.1.0</string>
+	<string>0.0.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.0.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>12.0</string>
 	<key>LSUIElement</key>

--- a/native/macos/Info.plist
+++ b/native/macos/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.qcytsn.dsh-dafeiyu.helper</string>
+	<key>CFBundleName</key>
+	<string>DSH 大肥鱼 Helper</string>
+	<key>CFBundleDisplayName</key>
+	<string>DSH 大肥鱼 Helper</string>
+	<key>CFBundleExecutable</key>
+	<string>dsh-dafeiyu-helper</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>

--- a/native/macos/README.md
+++ b/native/macos/README.md
@@ -55,9 +55,26 @@ PyObjC 在 macOS 26 上崩溃 → EPIPE 未捕获 → 整个 dsh 服务器退出
 native/macos/build.sh
 ```
 
-产物：`runtime/bin/darwin-arm64/dsh-dafeiyu-helper.app`（arm64 薄二进制，
-ad-hoc 签名，素材打进 `Contents/Resources/assets`）。要求 Xcode Command Line
-Tools（`swiftc`）。
+产物：`runtime/bin/darwin/dsh-dafeiyu-helper.app`（Universal 二进制
+arm64 + x86_64，最低 macOS 12.0，ad-hoc 签名，素材打进
+`Contents/Resources/assets`）。要求 Xcode Command Line Tools（`swiftc`）。
+
+## 用户安装（macOS 端用户）
+
+普通用户**不需要**自行构建或运行本目录的源码。直接用 DSH 的插件命令安装
+发布包即可（发布包已内置 macOS 原生 Helper）：
+
+```bash
+pnpm exec dsh plugin --profile web add dsh-dafeiyu
+```
+
+或从 GitHub Releases 下载 `dsh-dafeiyu-<version>.tgz` 后安装：
+
+```bash
+pnpm exec dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
+```
+
+完整安装步骤见主 README 的「macOS 用户」小节。
 
 ## 接入
 

--- a/native/macos/README.md
+++ b/native/macos/README.md
@@ -59,10 +59,18 @@ native/macos/build.sh
 arm64 + x86_64，最低 macOS 12.0，ad-hoc 签名，素材打进
 `Contents/Resources/assets`）。要求 Xcode Command Line Tools（`swiftc`）。
 
+## 签名与 Gatekeeper 边界
+
+自动构建会执行 ad-hoc 签名，并用 `codesign --verify --deep --strict` 检查应用包
+完整性；这不等同于 Apple Developer ID 签名或公证。当前 Alpha 集成没有仓库可用的
+Developer ID / Notary 凭据，因此浏览器下载并带有隔离属性的包仍可能被 Gatekeeper
+拦截。正式签名与公证继续在 #24 跟踪，不能把 ad-hoc 签名描述为正式分发签名。
+
 ## 用户安装（macOS 端用户）
 
-普通用户**不需要**自行构建或运行本目录的源码。直接用 DSH 的插件命令安装
-发布包即可（发布包已内置 macOS 原生 Helper）：
+原生 Helper 当前仍在 `main` 的 Unreleased 阶段，npm `latest` 0.1.3 尚未包含。
+下一版本发布后，普通用户**不需要**自行构建或运行本目录的源码，直接用 DSH 的
+插件命令安装即可：
 
 ```bash
 pnpm exec dsh plugin --profile web add dsh-dafeiyu

--- a/native/macos/README.md
+++ b/native/macos/README.md
@@ -1,0 +1,82 @@
+# dsh-dafeiyu macOS 原生助手
+
+> **AI 辅助生成**：本目录的 Swift 源码与构建产物由 AI 辅助生成，经人工
+> review 与调试后合入（详见主 README 的「macOS 原生适配」章节）。
+
+这是 `dsh-dafeiyu` 桌面大肥鱼的 **macOS 原生实现**：用 Swift + 纯
+AppKit 重写了原来的 Qt/PySide6 helper 和 PyObjC 原生窗口原型，不依赖
+Python、Qt 或 PyObjC，因此彻底绕开了「anaconda Python 3.13 + PySide6 /
+PyObjC 在 macOS 26 上崩溃 → EPIPE 未捕获 → 整个 dsh 服务器退出」的故障链。
+
+## 重做了哪些地方
+
+- Qt/PySide6 可视窗口 → Swift + AppKit（NSPanel 原生实现）
+- PyObjC 原生窗口原型 → Swift 实现（同一套 NSPanel 方案）
+- 全屏置顶：`canJoinAllSpaces` + `fullScreenAuxiliary` + `.floating` 层级，
+  每 2 秒重新断言，全屏 App 下保持前端
+- 权限：`UNUserNotificationCenter` 通知授权 + `AXIsProcessTrustedWithOptions`
+  辅助功能检查/请求
+- EPIPE 兜底：helper 崩溃不拖垮 dsh 服务器
+- 渲染/交互修复：flipped 视图图片倒置、拖拽 1:1 跟手、拖拽时人物与气泡同步
+- 布局迁移：旧 Qt top-left 坐标 → AppKit bottom-left，文件路径不变
+
+## 兼容性
+
+- Universal binary：Apple Silicon（arm64）+ Intel（x86_64）
+- 最低系统：macOS 12.0（`build.sh` 以 `-target *-apple-macosx12.0` 构建）
+- 构建工具：Xcode Command Line Tools（`swiftc` + `lipo` + `codesign`）
+
+## 功能（与 Windows/Qt 版对齐）
+
+- 状态展示：`IDLE / THINKING / WORKING / WAITING / SUCCESS / ERROR /
+  DISCONNECTED`，状态卡 + 多任务卡（颜色、图标、截断文本）
+- 动画内核：`runtime/animation_model.py` 的忠实移植（clips、pulse、
+  overlay、idle 微动作、crossfade、程序化 motion：breathe/think/work/
+  wait/bounce/shake/dizzy/float + 行走摆动）
+- 交互：左键拖拽（带 dragging 动画并持久化位置）、单击摸头/戳/尾巴、
+  双击、右键菜单（大小/气泡大小/减少动态/打开 WebUI/辅助功能权限/
+  本次隐藏/本次关闭）
+- 全屏置顶：`NSWindow.CollectionBehavior` 的 `canJoinAllSpaces` +
+  `fullScreenAuxiliary` + `stationary`，`NSWindow.Level.floating`，每 2 秒
+  重新断言层级并 `orderFrontRegardless()`，全屏 App 下依然在前端
+- 布局持久化：`~/.dsh/dsh-dafeiyu/layout.json`（与旧版同路径；首次启动
+  自动迁移旧 Qt 版 top-left 坐标到 AppKit bottom-left）
+- 权限（苹果官方接口）：UserNotifications 通知授权
+  （SUCCESS/ERROR 脉冲时提示，失败则回退到 beep + 窗口抖动）；
+  Accessibility 检查/请求（`AXIsProcessTrustedWithOptions` + 系统设置
+  深链），可在右键菜单触发
+- 协议兼容：与插件 `src/protocol.js` 完全一致（ready/pong/closed +
+  state/pulse/task/tasks/config/shutdown），支持 `--headless`
+  `--event-log` `--snapshot` 调试参数
+
+## 构建
+
+```bash
+native/macos/build.sh
+```
+
+产物：`runtime/bin/darwin-arm64/dsh-dafeiyu-helper.app`（arm64 薄二进制，
+ad-hoc 签名，素材打进 `Contents/Resources/assets`）。要求 Xcode Command Line
+Tools（`swiftc`）。
+
+## 接入
+
+`src/helper-process.js` 在 `process.platform === 'darwin'` 时优先使用该
+原生 helper（与 Windows 的 win32-x64 EXE 同路径模式）；helper 崩溃时由
+插件自动重启，且 stdin/stdout/stderr 的 EPIPE 已被兜底，不再拖垮 dsh。
+
+重新打包并安装到 dsh profile：
+
+```bash
+npm pack          # 生成 dsh-dafeiyu-<version>.tgz
+# 把 tarball 路径写入 ~/.dsh/profiles/web/package.json 的 dependencies，
+# 并把 dsh-dafeiyu 加回 bundles 列表，然后解包到
+# ~/.dsh/profiles/web/node_modules/dsh-dafeiyu
+```
+
+## 回退
+
+- 临时停用：dsh WebUI 设置里关闭 dsh-dafeiyu，或右键宠物 → 本次关闭
+- 彻底移除：从 `~/.dsh/profiles/web/package.json` 删掉 dsh-dafeiyu 依赖和
+  bundle 项，删除 `node_modules/dsh-dafeiyu`，重启 dsh 服务
+- 旧版插件如需找回，可从之前安装的 `.tgz` 或 npm 版本恢复

--- a/native/macos/Sources/AnimationModel.swift
+++ b/native/macos/Sources/AnimationModel.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// Port of the original `runtime/animation_model.py` — a pure animation state
+/// machine with no UI dependency. Keeps durable DSH state separate from
+/// temporary visual overlays so a click, idle micro-animation, or success
+/// pulse always returns to the newest Agent state.
+final class AnimationModel {
+    struct Clip {
+        let name: String
+        let frames: [String]
+        let frameMs: Int
+        let loop: Bool
+        let motion: String?
+    }
+
+    static let states: Set<String> = [
+        "IDLE", "THINKING", "WORKING", "WAITING", "SUCCESS", "ERROR", "DISCONNECTED",
+    ]
+
+    private static let nonCrossfadeClips: Set<String> = ["blink", "glance", "dragging"]
+
+    /// Same rules as the Python `crossfade_duration`: expression frames stay
+    /// crisp, dragging switches atomically.
+    static func crossfadeDuration(previousClip: String, currentClip: String) -> Double? {
+        if nonCrossfadeClips.contains(previousClip) || nonCrossfadeClips.contains(currentClip) {
+            return nil
+        }
+        return previousClip != currentClip ? 0.10 : 0.045
+    }
+
+    private(set) var clips: [String: Clip] = [:]
+    private var stateMap: [String: String] = [:]
+    private var workingActivityMap: [String: String] = [:]
+    private(set) var idleMicroClips: [String] = []
+
+    private(set) var baseState = "IDLE"
+    private(set) var baseActivity: String?
+    private(set) var baseClipName = "idle"
+    private(set) var overlayClipName: String?
+    private(set) var pulseState: String?
+    private(set) var pulseDeadlineMs: Int?
+    private(set) var pulseClipName: String?
+    private(set) var activeClipName = "idle"
+    private(set) var frameIndex = 0
+    private(set) var frameElapsedMs = 0
+
+    init(manifest: [String: Any]) {
+        if let clipsDict = manifest["clips"] as? [String: Any] {
+            for (name, value) in clipsDict {
+                guard let v = value as? [String: Any],
+                      let frames = v["frames"] as? [String] else { continue }
+                clips[name] = Clip(
+                    name: name,
+                    frames: frames,
+                    frameMs: Self.asInt(v["frameMs"], fallback: 180),
+                    loop: (v["loop"] as? Bool) ?? false,
+                    motion: v["motion"] as? String
+                )
+            }
+        }
+        if let map = manifest["stateMap"] as? [String: String] { stateMap = map }
+        if let map = manifest["workingActivityMap"] as? [String: String] { workingActivityMap = map }
+        if let micros = manifest["idleMicroClips"] as? [String] { idleMicroClips = micros }
+        if let idleClip = stateMap["IDLE"], !idleClip.isEmpty {
+            baseClipName = idleClip
+            activeClipName = idleClip
+        }
+    }
+
+    var activeClip: Clip {
+        clips[activeClipName] ?? Clip(name: activeClipName, frames: [], frameMs: 180, loop: false, motion: nil)
+    }
+
+    var frame: String {
+        activeClip.frames.isEmpty ? "" : activeClip.frames[frameIndex]
+    }
+
+    func applyState(_ state: String, activity: String? = nil) {
+        guard Self.states.contains(state) else { return }
+        baseState = state
+        baseActivity = activity
+        baseClipName = clip(for: state, activity: activity)
+        pulseState = nil
+        pulseDeadlineMs = nil
+        pulseClipName = nil
+        if overlayClipName == nil {
+            activate(baseClipName)
+        }
+    }
+
+    func applyPulse(state: String, ttlMs: Int, nowMs: Int, resumeState: String?, resumeActivity: String?) {
+        guard Self.states.contains(state), ttlMs > 0 else { return }
+        if let resume = resumeState, Self.states.contains(resume) {
+            baseState = resume
+            baseActivity = resumeActivity
+            baseClipName = clip(for: resume, activity: resumeActivity)
+        }
+        pulseState = state
+        pulseDeadlineMs = nowMs + ttlMs
+        pulseClipName = clip(for: state, activity: nil)
+        if overlayClipName == nil {
+            activate(pulseClipName ?? baseClipName)
+        }
+    }
+
+    @discardableResult
+    func playOverlay(_ clipName: String) -> Bool {
+        guard clips[clipName] != nil else { return false }
+        overlayClipName = clipName
+        activate(clipName)
+        return true
+    }
+
+    func clearOverlay() {
+        overlayClipName = nil
+        activate(underlayClipName)
+    }
+
+    @discardableResult
+    func playIdleMicro(index: Int = 0) -> Bool {
+        guard baseState == "IDLE", overlayClipName == nil, pulseState == nil else { return false }
+        guard !idleMicroClips.isEmpty else { return false }
+        return playOverlay(idleMicroClips[index % idleMicroClips.count])
+    }
+
+    func advance(elapsedMs: Int, nowMs: Int) {
+        guard elapsedMs >= 0 else { return }
+        if let deadline = pulseDeadlineMs, nowMs >= deadline {
+            pulseState = nil
+            pulseDeadlineMs = nil
+            pulseClipName = nil
+            if overlayClipName == nil {
+                activate(baseClipName)
+            }
+        }
+
+        let clip = activeClip
+        guard clip.frames.count > 1 else { return }
+        frameElapsedMs += elapsedMs
+        while frameElapsedMs >= clip.frameMs {
+            frameElapsedMs -= clip.frameMs
+            if frameIndex + 1 < clip.frames.count {
+                frameIndex += 1
+                continue
+            }
+            if clip.loop {
+                frameIndex = 0
+                continue
+            }
+            if overlayClipName != nil {
+                overlayClipName = nil
+                activate(underlayClipName)
+            } else {
+                frameIndex = clip.frames.count - 1
+            }
+            break
+        }
+    }
+
+    func clip(for state: String, activity: String?) -> String {
+        if state == "WORKING", let activity = activity, let mapped = workingActivityMap[activity] {
+            return mapped
+        }
+        return stateMap[state] ?? stateMap["IDLE"] ?? baseClipName
+    }
+
+    private var underlayClipName: String {
+        pulseClipName ?? baseClipName
+    }
+
+    private func activate(_ clipName: String) {
+        guard activeClipName != clipName else { return }
+        activeClipName = clipName
+        frameIndex = 0
+        frameElapsedMs = 0
+    }
+
+    private static func asInt(_ value: Any?, fallback: Int) -> Int {
+        if let i = value as? Int { return i }
+        if let d = value as? Double { return Int(d) }
+        if let s = value as? String { return Int(s) ?? fallback }
+        return fallback
+    }
+}

--- a/native/macos/Sources/LayoutStore.swift
+++ b/native/macos/Sources/LayoutStore.swift
@@ -12,6 +12,8 @@ struct PetLayout {
     var scale: Double = 1.0
     var bubbleScale: Double = 1.0
     var reducedMotion: Bool = false
+    var bubbleMode: String = "always"
+    var bubbleStates: [String] = ["SUCCESS", "ERROR", "WAITING"]
     /// Set once the native helper has written the file. Lets us migrate the
     /// old Qt helper's top-left coordinates to AppKit's bottom-left origin.
     var coordinateSpace: String?
@@ -37,11 +39,15 @@ struct PetLayout {
         if let v = json["y"] as? Int { layout.y = v }
         if let v = json["petX"] as? Int { layout.petX = v }
         if let v = json["petY"] as? Int { layout.petY = v }
-        if let d = json["scale"] as? Double { layout.scale = min(1.4, max(0.7, d)) }
-        else if let i = json["scale"] as? Int { layout.scale = min(1.4, max(0.7, Double(i))) }
+        if let d = json["scale"] as? Double { layout.scale = min(1.4, max(0.55, d)) }
+        else if let i = json["scale"] as? Int { layout.scale = min(1.4, max(0.55, Double(i))) }
         if let d = json["bubbleScale"] as? Double { layout.bubbleScale = min(1.2, max(0.8, d)) }
         else if let i = json["bubbleScale"] as? Int { layout.bubbleScale = min(1.2, max(0.8, Double(i))) }
         if let b = json["reducedMotion"] as? Bool { layout.reducedMotion = b }
+        if let mode = json["bubbleMode"] as? String, ["always", "hidden", "custom"].contains(mode) {
+            layout.bubbleMode = mode
+        }
+        if let states = json["bubbleStates"] as? [String] { layout.bubbleStates = states }
         if let s = json["coordinateSpace"] as? String { layout.coordinateSpace = s }
         return layout
     }
@@ -56,6 +62,8 @@ struct PetLayout {
             "scale": scale,
             "bubbleScale": bubbleScale,
             "reducedMotion": reducedMotion,
+            "bubbleMode": bubbleMode,
+            "bubbleStates": bubbleStates,
             "coordinateSpace": "appkit-bottom-left",
         ]
         guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.prettyPrinted, .sortedKeys]) else {

--- a/native/macos/Sources/LayoutStore.swift
+++ b/native/macos/Sources/LayoutStore.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Port of the original `runtime/layout_store.py`. Persists the pet window
+/// geometry in the same JSON file the original helper uses
+/// (`$DSH_HOME/dsh-dafeiyu/layout.json` or `~/.dsh/dsh-dafeiyu/layout.json`).
+struct PetLayout {
+    var version: Int = 1
+    var x: Int?
+    var y: Int?
+    var petX: Int?
+    var petY: Int?
+    var scale: Double = 1.0
+    var bubbleScale: Double = 1.0
+    var reducedMotion: Bool = false
+    /// Set once the native helper has written the file. Lets us migrate the
+    /// old Qt helper's top-left coordinates to AppKit's bottom-left origin.
+    var coordinateSpace: String?
+
+    static func defaultPath() -> URL {
+        if let override = ProcessInfo.processInfo.environment["DSH_DAFEIYU_LAYOUT_PATH"] {
+            return URL(fileURLWithPath: override)
+        }
+        if let dshHome = ProcessInfo.processInfo.environment["DSH_HOME"] {
+            return URL(fileURLWithPath: dshHome).appendingPathComponent("dsh-dafeiyu/layout.json")
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".dsh/dsh-dafeiyu/layout.json")
+    }
+
+    static func load(from url: URL) -> PetLayout {
+        var layout = PetLayout()
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return layout
+        }
+        if let v = json["x"] as? Int { layout.x = v }
+        if let v = json["y"] as? Int { layout.y = v }
+        if let v = json["petX"] as? Int { layout.petX = v }
+        if let v = json["petY"] as? Int { layout.petY = v }
+        if let d = json["scale"] as? Double { layout.scale = min(1.4, max(0.7, d)) }
+        else if let i = json["scale"] as? Int { layout.scale = min(1.4, max(0.7, Double(i))) }
+        if let d = json["bubbleScale"] as? Double { layout.bubbleScale = min(1.2, max(0.8, d)) }
+        else if let i = json["bubbleScale"] as? Int { layout.bubbleScale = min(1.2, max(0.8, Double(i))) }
+        if let b = json["reducedMotion"] as? Bool { layout.reducedMotion = b }
+        if let s = json["coordinateSpace"] as? String { layout.coordinateSpace = s }
+        return layout
+    }
+
+    func save(to url: URL) {
+        let dict: [String: Any] = [
+            "version": version,
+            "x": x ?? NSNull(),
+            "y": y ?? NSNull(),
+            "petX": petX ?? NSNull(),
+            "petY": petY ?? NSNull(),
+            "scale": scale,
+            "bubbleScale": bubbleScale,
+            "reducedMotion": reducedMotion,
+            "coordinateSpace": "appkit-bottom-left",
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.prettyPrinted, .sortedKeys]) else {
+            return
+        }
+        do {
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            FileHandle.standardError.write(Data("Unable to save BigFish layout: \(error)\n".utf8))
+        }
+    }
+}

--- a/native/macos/Sources/Permissions.swift
+++ b/native/macos/Sources/Permissions.swift
@@ -1,0 +1,43 @@
+import AppKit
+import ApplicationServices
+import UserNotifications
+
+/// Apple-official permission handling for the companion helper.
+/// - Notifications: modern UNUserNotificationCenter (works because the helper
+///   is a proper .app bundle with an Info.plist and ad-hoc signature).
+/// - Accessibility: AXIsProcessTrusted / AXIsProcessTrustedWithOptions with a
+///   System Settings deep link when the user asks for it.
+enum Permissions {
+    static func requestNotificationAuthorizationIfNeeded() {
+        // UNUserNotificationCenter requires a bundle identifier; guard for
+        // bare-binary development runs.
+        guard Bundle.main.bundleIdentifier != nil else { return }
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                center.requestAuthorization(options: [.alert, .sound]) { _, _ in }
+            default:
+                break
+            }
+        }
+    }
+
+    static var isAccessibilityTrusted: Bool {
+        AXIsProcessTrusted()
+    }
+
+    /// Show the system prompt (if possible) or open System Settings.
+    static func requestAccessibility() {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        if !AXIsProcessTrustedWithOptions(options) {
+            openAccessibilitySettings()
+        }
+    }
+
+    static func openAccessibilitySettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}

--- a/native/macos/Sources/PetController.swift
+++ b/native/macos/Sources/PetController.swift
@@ -58,6 +58,9 @@ final class PetController: NSObject {
     var bubbleScale: Double
     var reducedMotion: Bool
     var activityLevel: String
+    var soundEnabled: Bool
+    var bubbleMode: String
+    var bubbleStates: [String]
 
     // Durable status
     var displayState = "IDLE"
@@ -126,6 +129,14 @@ final class PetController: NSObject {
             self.reducedMotion = layout.reducedMotion
         }
         self.activityLevel = env["DSH_DAFEIYU_ACTIVITY_LEVEL"] ?? "normal"
+        self.soundEnabled = env["DSH_DAFEIYU_SOUND_ENABLED"] != "0"
+        let configuredBubbleMode = env["DSH_DAFEIYU_BUBBLE_MODE"]
+        self.bubbleMode = ["always", "hidden", "custom"].contains(configuredBubbleMode ?? "")
+            ? configuredBubbleMode!
+            : layout.bubbleMode
+        self.bubbleStates = env["DSH_DAFEIYU_BUBBLE_STATES"]
+            .map { $0.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) } }
+            ?? layout.bubbleStates
         self.lastTickMs = Self.nowMs()
         super.init()
 
@@ -253,6 +264,8 @@ final class PetController: NSObject {
         layout.scale = scale
         layout.bubbleScale = bubbleScale
         layout.reducedMotion = reducedMotion
+        layout.bubbleMode = bubbleMode
+        layout.bubbleStates = bubbleStates
         layout.save(to: layoutURL)
     }
 
@@ -449,7 +462,7 @@ final class PetController: NSObject {
         let menu = NSMenu(title: "DSH 大肥鱼")
 
         let sizeMenu = NSMenu(title: "大小")
-        for (label, value) in [("小", 0.8), ("标准", 1.0), ("大", 1.25)] {
+        for (label, value) in [("迷你", 0.6), ("小", 0.8), ("标准", 1.0), ("大", 1.25)] {
             let item = NSMenuItem(title: label, action: #selector(changeSize(_:)), keyEquivalent: "")
             item.target = self
             item.tag = Int(value * 100)
@@ -502,12 +515,14 @@ final class PetController: NSObject {
         scale = Self.clampedScale(Double(sender.tag) / 100.0)
         resizeAndReposition()
         saveLayout()
+        reportSettings(["scale": scale])
     }
 
     @objc private func changeBubbleScale(_ sender: NSMenuItem) {
         bubbleScale = Self.clampedBubbleScale(Double(sender.tag) / 100.0)
         resizeAndReposition()
         saveLayout()
+        reportSettings(["bubbleScale": bubbleScale])
     }
 
     @objc private func toggleReducedMotion(_ sender: NSMenuItem) {
@@ -519,6 +534,7 @@ final class PetController: NSObject {
             scheduleMicro()
         }
         saveLayout()
+        reportSettings(["reducedMotion": reducedMotion])
         contentView?.needsDisplay = true
     }
 
@@ -642,11 +658,22 @@ final class PetController: NSObject {
             }
             changed = true
         }
+        if let value = message["soundEnabled"] as? Bool {
+            soundEnabled = value
+        }
         if let value = message["activityLevel"] as? String, ["quiet", "normal", "lively"].contains(value) {
             activityLevel = value
             if !reducedMotion {
                 scheduleMicro()
             }
+        }
+        if let value = message["bubbleMode"] as? String, ["always", "hidden", "custom"].contains(value) {
+            bubbleMode = value
+            changed = true
+        }
+        if let value = message["bubbleStates"] as? [String] {
+            bubbleStates = value
+            changed = true
         }
         if changed {
             resizeAndReposition()
@@ -654,7 +681,7 @@ final class PetController: NSObject {
         }
     }
 
-    func quit(reason: String) {
+    func quit(reason: String, reportClosed: Bool = true) {
         guard !quitting else { return }
         quitting = true
         saveLayout()
@@ -662,12 +689,14 @@ final class PetController: NSObject {
         keepFrontTimer?.invalidate()
         microTimer?.invalidate()
         shakeTimer?.invalidate()
-        ProtocolIO.shared.write([
-            "protocolVersion": 1,
-            "kind": "closed",
-            "reason": reason,
-            "timestamp": Self.nowMs(),
-        ])
+        if reportClosed {
+            ProtocolIO.shared.write([
+                "protocolVersion": 1,
+                "kind": "closed",
+                "reason": reason,
+                "timestamp": Self.nowMs(),
+            ])
+        }
         panel?.close()
         NSApp.terminate(nil)
     }
@@ -706,15 +735,34 @@ final class PetController: NSObject {
         return nil
     }
 
+    private func bubbleVisible() -> Bool {
+        if bubbleMode == "hidden" { return false }
+        if bubbleMode == "always" { return true }
+        if tasks.count >= 2 {
+            return tasks.contains { task in
+                guard let state = task["state"] as? String else { return false }
+                return bubbleStates.contains(state)
+            }
+        }
+        return bubbleStates.contains(overlayState ?? statusState)
+    }
+
     private func notifyAlert(_ state: String) {
-        NSSound.beep()
+        if soundEnabled {
+            let filename = state == "SUCCESS" ? "success" : "error"
+            if let url = Bundle.main.resourceURL?
+                .appendingPathComponent("assets/sounds/\(filename).wav"),
+               let sound = NSSound(contentsOf: url, byReference: true) {
+                sound.play()
+            }
+        }
         shakeWindow()
         Permissions.requestNotificationAuthorizationIfNeeded()
         guard Bundle.main.bundleIdentifier != nil else { return }
         let content = UNMutableNotificationContent()
         content.title = state == "SUCCESS" ? "任务完成" : "任务出错"
         content.body = state == "SUCCESS" ? "DSH 任务已完成" : "DSH 任务遇到问题"
-        content.sound = .default
+        content.sound = soundEnabled ? .default : nil
         let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request) { error in
             if let error = error {
@@ -863,6 +911,7 @@ final class PetController: NSObject {
     }
 
     func drawCard(in view: NSView) {
+        guard bubbleVisible() else { return }
         let rect = bubbleRect()
         if tasks.count >= 2 {
             drawTaskCard(rect: rect)
@@ -1058,7 +1107,7 @@ final class PetController: NSObject {
     }
 
     static func clampedScale(_ value: Double) -> Double {
-        min(1.4, max(0.7, value))
+        min(1.4, max(0.55, value))
     }
 
     static func clampedBubbleScale(_ value: Double) -> Double {
@@ -1086,7 +1135,15 @@ final class PetController: NSObject {
     }
 
     private static func nowMs() -> Int {
-        Int(CACurrentMediaTime() * 1000)
+        Int(Date().timeIntervalSince1970 * 1000)
+    }
+
+    private func reportSettings(_ values: [String: Any]) {
+        ProtocolIO.shared.write([
+            "protocolVersion": 1,
+            "kind": "settings",
+            "timestamp": Self.nowMs(),
+        ].merging(values) { _, new in new })
     }
 
     private static func hex(_ hex: String) -> NSColor {

--- a/native/macos/Sources/PetController.swift
+++ b/native/macos/Sources/PetController.swift
@@ -1,0 +1,1102 @@
+import AppKit
+import QuartzCore
+import UserNotifications
+
+/// Native AppKit companion controller. Implements the full BigFish feature set
+/// on Apple's official APIs:
+/// - Borderless transparent NSPanel, `fullScreenAuxiliary` + `canJoinAllSpaces`
+///   + `.floating` level, re-asserted every 2 s so the pet stays above
+///   full-screen apps.
+/// - Faithful port of the Qt helper's status card, multi-task card, animation
+///   model, procedural motion, drag/click interactions, right-click menu,
+///   idle micro-animations and layout persistence.
+/// - Apple official permission handling (UserNotifications + Accessibility).
+final class PetController: NSObject {
+    static let labels: [String: String] = [
+        "IDLE": "休息中",
+        "THINKING": "思考中",
+        "WORKING": "干活中",
+        "WAITING": "等你呢",
+        "SUCCESS": "完成啦",
+        "ERROR": "出问题了",
+        "DISCONNECTED": "已断开",
+    ]
+
+    static let statusColors: [String: (bg: String, fg: String)] = [
+        "SUCCESS": ("#D9F7E4", "#12B85A"),
+        "ERROR": ("#FDE3E3", "#E5484D"),
+        "WAITING": ("#FFF0CE", "#D88A00"),
+        "THINKING": ("#E2ECFF", "#4C78E8"),
+        "WORKING": ("#DDEBFF", "#3478F6"),
+        "DISCONNECTED": ("#ECEEF1", "#7B818A"),
+    ]
+
+    static let persistentStates: Set<String> = ["THINKING", "WORKING", "WAITING", "ERROR"]
+
+    static let microIntervals: [String: (Double, Double)] = [
+        "quiet": (12, 24),
+        "normal": (6.5, 12.5),
+        "lively": (3.5, 8),
+    ]
+
+    let model: AnimationModel
+    let manifest: [String: Any]
+    let assetRoot: URL
+    let layoutURL: URL
+    let webuiURL: String
+    let eventLogURL: URL?
+    let snapshotURL: URL?
+
+    private(set) var frames: [String: NSImage] = [:]
+    private var maxFrameWidth: CGFloat = 238
+    private var maxFrameHeight: CGFloat = 260
+
+    private(set) var panel: NSPanel?
+    private(set) var contentView: PetView?
+
+    var scale: Double
+    var bubbleScale: Double
+    var reducedMotion: Bool
+    var activityLevel: String
+
+    // Durable status
+    var displayState = "IDLE"
+    var statusState = "IDLE"
+    var statusMessage = "我在这儿等新任务哦"
+    var statusDetail = "DSH · 等待下一次任务"
+    var statusDeadlineMs: Int?
+    var overlayState: String?
+    var overlayMessage = ""
+    var overlayDetail = ""
+    var overlayDeadlineMs: Int?
+    var task = ""
+    var tasks: [[String: Any]] = []
+
+    // Geometry (pet anchor in AppKit bottom-left coordinates)
+    private var petX: CGFloat = 0
+    private var petY: CGFloat = 0
+
+    private(set) var dragging = false
+
+    private var animTimer: Timer?
+    private var keepFrontTimer: Timer?
+    private var microTimer: Timer?
+    private var shakeTimer: Timer?
+    private var shakeOrigin: NSPoint?
+    private var shakeCount = 0
+    private var lastTickMs: Int
+    private var dragPetOffsetX: CGFloat = 0
+    private var dragPetOffsetY: CGFloat = 8
+    private var fadeFromFrame: String?
+    private var fadeStarted: CFTimeInterval = 0
+    private var fadeDuration: Double = 0.15
+    private var snapshotSaved = false
+    private var quitting = false
+
+    init(model: AnimationModel,
+         manifest: [String: Any],
+         assetRoot: URL,
+         layoutURL: URL,
+         webuiURL: String,
+         eventLogURL: URL?,
+         snapshotURL: URL?) {
+        self.model = model
+        self.manifest = manifest
+        self.assetRoot = assetRoot
+        self.layoutURL = layoutURL
+        self.webuiURL = webuiURL
+        self.eventLogURL = eventLogURL
+        self.snapshotURL = snapshotURL
+
+        let env = ProcessInfo.processInfo.environment
+        let layout = PetLayout.load(from: layoutURL)
+        if let raw = env["DSH_DAFEIYU_SCALE"], let value = Double(raw) {
+            self.scale = Self.clampedScale(value)
+        } else {
+            self.scale = Self.clampedScale(layout.scale)
+        }
+        if let raw = env["DSH_DAFEIYU_BUBBLE_SCALE"], let value = Double(raw) {
+            self.bubbleScale = Self.clampedBubbleScale(value)
+        } else {
+            self.bubbleScale = Self.clampedBubbleScale(layout.bubbleScale)
+        }
+        if let raw = env["DSH_DAFEIYU_REDUCED_MOTION"] {
+            self.reducedMotion = raw == "1"
+        } else {
+            self.reducedMotion = layout.reducedMotion
+        }
+        self.activityLevel = env["DSH_DAFEIYU_ACTIVITY_LEVEL"] ?? "normal"
+        self.lastTickMs = Self.nowMs()
+        super.init()
+
+        if let mfw = manifest["maxFrameWidth"] as? Int { maxFrameWidth = CGFloat(mfw) }
+        if let mfh = manifest["maxFrameHeight"] as? Int { maxFrameHeight = CGFloat(mfh) }
+        loadFrames()
+        if !isHeadless() {
+            buildWindow()
+            restorePosition()
+            startTimers()
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(screenParametersChanged),
+                name: NSApplication.didChangeScreenParametersNotification,
+                object: nil
+            )
+        }
+    }
+
+    private func isHeadless() -> Bool {
+        ProcessInfo.processInfo.arguments.contains("--headless")
+    }
+
+    // MARK: - Frames & geometry
+
+    private func loadFrames() {
+        for clip in model.clips.values {
+            for frame in clip.frames where frames[frame] == nil {
+                if let image = NSImage(contentsOf: assetRoot.appendingPathComponent(frame)) {
+                    frames[frame] = image
+                }
+            }
+        }
+    }
+
+    private var petWidth: CGFloat { maxFrameWidth * scale }
+    private var petHeight: CGFloat { maxFrameHeight * scale }
+
+    private var cardHeightPoints: CGFloat {
+        if tasks.count >= 2 {
+            let rows = min(tasks.count, 3)
+            return (58 + CGFloat(rows) * 26) * bubbleScale
+        }
+        return 84 * bubbleScale
+    }
+
+    private var cardWidthPoints: CGFloat { 420 * bubbleScale }
+
+    private func windowSize() -> NSSize {
+        NSSize(
+            width: max(petWidth + 50, cardWidthPoints + 28),
+            height: petHeight + cardHeightPoints + 34
+        )
+    }
+
+    func petRect() -> NSRect {
+        let viewSize = contentView?.bounds.size ?? windowSize()
+        let offsetX = min(max(petX - (panel?.frame.origin.x ?? 0), 0), viewSize.width - petWidth)
+        return NSRect(x: offsetX, y: viewSize.height - petHeight - 8, width: petWidth, height: petHeight)
+    }
+
+    func bubbleRect() -> NSRect {
+        let viewSize = contentView?.bounds.size ?? windowSize()
+        let cardWidth = cardWidthPoints
+        let cardHeight = cardHeightPoints
+        let petCenterX = petRect().midX
+        let margin: CGFloat = 14
+        let minX = margin
+        let maxX = max(minX, viewSize.width - cardWidth - margin)
+        let cardX = min(max(petCenterX - cardWidth / 2, minX), maxX)
+        return NSRect(x: cardX, y: 7, width: cardWidth, height: cardHeight)
+    }
+
+    private func screenContaining(_ point: NSPoint) -> NSScreen? {
+        NSScreen.screens.first { $0.frame.contains(point) }
+    }
+
+    func moveToPet(_ x: CGFloat, _ y: CGFloat) {
+        guard let panel = panel else { return }
+        let size = windowSize()
+        let geometry = screenContaining(NSPoint(x: x, y: y))?.visibleFrame ?? NSScreen.main?.visibleFrame
+        let minX = geometry?.minX ?? 0
+        let maxX = max(minX, (geometry?.maxX ?? minX + size.width) - size.width + 1)
+        let centerOffsetX = (size.width - petWidth) / 2
+        let windowX = min(max(x - centerOffsetX, minX), maxX)
+        let offsetX = min(max(x - windowX, 0), size.width - petWidth)
+        self.petX = windowX + offsetX
+
+        let minY = geometry?.minY ?? 0
+        let maxY = max(minY, (geometry?.maxY ?? minY + size.height) - size.height + 1)
+        let windowY = min(max(y - 8, minY), maxY)
+        self.petY = windowY + 8
+
+        panel.setFrameOrigin(NSPoint(x: windowX, y: windowY))
+        contentView?.needsDisplay = true
+    }
+
+    private func restorePosition() {
+        let layout = PetLayout.load(from: layoutURL)
+        let screenHeight = NSScreen.main?.frame.height ?? 982
+        if let px = layout.petX, let py = layout.petY {
+            let ax = CGFloat(px)
+            var ay = CGFloat(py)
+            if layout.coordinateSpace == nil && ay < screenHeight * 0.5 {
+                // Legacy Qt layout stores top-left coordinates; convert to
+                // AppKit bottom-left before first use.
+                ay = screenHeight - (ay + petHeight)
+            }
+            moveToPet(ax, ay)
+        } else {
+            let geometry = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1512, height: 982)
+            moveToPet(geometry.maxX - petWidth - 24, geometry.minY + 24)
+        }
+        saveLayout()
+    }
+
+    func saveLayout() {
+        guard let panel = panel else { return }
+        let origin = panel.frame.origin
+        var layout = PetLayout()
+        layout.x = Int(origin.x.rounded())
+        layout.y = Int(origin.y.rounded())
+        layout.petX = Int(petX.rounded())
+        layout.petY = Int(petY.rounded())
+        layout.scale = scale
+        layout.bubbleScale = bubbleScale
+        layout.reducedMotion = reducedMotion
+        layout.save(to: layoutURL)
+    }
+
+    func resizeAndReposition() {
+        guard let panel = panel, let contentView = contentView else { return }
+        let size = windowSize()
+        let origin = panel.frame.origin
+        panel.setContentSize(size)
+        panel.setFrameOrigin(origin)
+        contentView.frame = NSRect(origin: .zero, size: size)
+        moveToPet(petX, petY)
+        contentView.needsDisplay = true
+    }
+
+    // MARK: - Window
+
+    private func buildWindow() {
+        let size = windowSize()
+        let panel = NSPanel(
+            contentRect: NSRect(x: 100, y: 100, width: size.width, height: size.height),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.hidesOnDeactivate = false
+        panel.ignoresMouseEvents = false
+        panel.isMovableByWindowBackground = false
+        panel.title = "DSH 大肥鱼"
+
+        let view = PetView(frame: NSRect(x: 0, y: 0, width: size.width, height: size.height))
+        view.controller = self
+        panel.contentView = view
+        self.panel = panel
+        self.contentView = view
+    }
+
+    func show() {
+        guard !isHeadless() else { return }
+        panel?.orderFrontRegardless()
+        keepFront()
+    }
+
+    @objc private func screenParametersChanged() {
+        moveToPet(petX, petY)
+    }
+
+    // MARK: - Timers
+
+    private func startAnimTimer() {
+        animTimer?.invalidate()
+        let interval = reducedMotion ? 0.04 : 0.02
+        animTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    private func startTimers() {
+        startAnimTimer()
+        keepFrontTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            self?.keepFront()
+        }
+        scheduleMicro()
+    }
+
+    private func keepFront() {
+        guard let panel = panel, !quitting else { return }
+        // Re-assert every 2 s: other apps or full-screen transitions can reset
+        // the level/collection behavior, which would hide the pet.
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.orderFrontRegardless()
+    }
+
+    private func scheduleMicro() {
+        microTimer?.invalidate()
+        guard !reducedMotion else { return }
+        let range = Self.microIntervals[activityLevel] ?? Self.microIntervals["normal"]!
+        let delay = Double.random(in: range.0...range.1)
+        microTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            guard let self = self else { return }
+            if !self.dragging {
+                let index = Int.random(in: 0..<max(1, self.model.idleMicroClips.count))
+                _ = self.model.playIdleMicro(index: index)
+                self.contentView?.needsDisplay = true
+            }
+            self.scheduleMicro()
+        }
+    }
+
+    private func tick() {
+        let now = Self.nowMs()
+        let elapsed = max(0, now - lastTickMs)
+        lastTickMs = now
+        let hadPulse = model.pulseState != nil
+        let previousFrame = model.frame
+        let previousClip = model.activeClipName
+        let modelElapsed = reducedMotion && model.activeClip.loop ? 0 : elapsed
+        model.advance(elapsedMs: modelElapsed, nowMs: now)
+        syncFrameTransition(previousFrame: previousFrame, previousClip: previousClip)
+        if hadPulse && model.pulseState == nil {
+            displayState = model.baseState
+        }
+        if let deadline = overlayDeadlineMs, now >= deadline {
+            clearOverlay()
+        }
+        contentView?.needsDisplay = true
+    }
+
+    private func syncFrameTransition(previousFrame: String, previousClip: String) {
+        let currentFrame = model.frame
+        guard currentFrame != previousFrame else { return }
+        if let duration = AnimationModel.crossfadeDuration(previousClip: previousClip, currentClip: model.activeClipName) {
+            fadeFromFrame = previousFrame
+            fadeStarted = CACurrentMediaTime()
+            fadeDuration = duration
+        } else {
+            fadeFromFrame = nil
+        }
+    }
+
+    // MARK: - Interaction
+
+    func beginDrag() {
+        guard !dragging else { return }
+        dragging = true
+        // Remember where the pet sits inside the window when the drag starts.
+        // During the drag the window moves directly; without re-anchoring the
+        // pet it would slide inside the window at the same rate and stay
+        // frozen on screen while the bubble moves — a visible desync.
+        let rect = petRect()
+        dragPetOffsetX = rect.minX
+        dragPetOffsetY = rect.minY
+        animTimer?.invalidate()
+        microTimer?.invalidate()
+        _ = model.playOverlay("dragging")
+        contentView?.needsDisplay = true
+    }
+
+    func updateDrag() {
+        guard let panel = panel else { return }
+        let viewSize = contentView?.bounds.size ?? windowSize()
+        // Re-anchor the pet to the window's current origin using the offsets
+        // captured at drag start, so the character and the bubble move as one.
+        petX = panel.frame.origin.x + dragPetOffsetX
+        petY = panel.frame.origin.y + (viewSize.height - dragPetOffsetY - petHeight)
+        contentView?.needsDisplay = true
+    }
+
+    func endDrag() {
+        guard dragging else { return }
+        let now = Self.nowMs()
+        model.advance(elapsedMs: 0, nowMs: now)
+        model.clearOverlay()
+        dragging = false
+        lastTickMs = now
+        startAnimTimer()
+        if !reducedMotion {
+            scheduleMicro()
+        }
+        saveLayout()
+        contentView?.needsDisplay = true
+    }
+
+    func handleClick(at point: NSPoint, clickCount: Int) {
+        if clickCount >= 2 {
+            _ = model.playOverlay("head_pat")
+            showOverlay("好啦好啦，知道你喜欢我~", statusDetail, statusState, 1800)
+            contentView?.needsDisplay = true
+            return
+        }
+        let rect = petRect()
+        let relativeX = max(0, point.x - rect.minX)
+        let relativeY = max(0, point.y - rect.minY)
+        if relativeY < rect.height * 0.45 {
+            _ = model.playOverlay("head_pat")
+            showOverlay("摸摸也不能让我少干活哦~", statusDetail, statusState, 1800)
+        } else if relativeX > rect.width * 0.72 {
+            _ = model.playOverlay("tail")
+            showOverlay("尾巴不是进度条啦！", statusDetail, statusState, 1500)
+        } else {
+            _ = model.playOverlay("poke")
+            showOverlay("戳我干嘛，任务还在跑呢", statusDetail, statusState, 1500)
+        }
+        contentView?.needsDisplay = true
+    }
+
+    func showMenu(with event: NSEvent) {
+        guard let contentView = contentView else { return }
+        let menu = NSMenu(title: "DSH 大肥鱼")
+
+        let sizeMenu = NSMenu(title: "大小")
+        for (label, value) in [("小", 0.8), ("标准", 1.0), ("大", 1.25)] {
+            let item = NSMenuItem(title: label, action: #selector(changeSize(_:)), keyEquivalent: "")
+            item.target = self
+            item.tag = Int(value * 100)
+            item.state = abs(scale - value) < 0.05 ? .on : .off
+            sizeMenu.addItem(item)
+        }
+        let sizeItem = NSMenuItem(title: "大小", action: nil, keyEquivalent: "")
+        sizeItem.submenu = sizeMenu
+        menu.addItem(sizeItem)
+
+        let bubbleMenu = NSMenu(title: "气泡大小")
+        for (label, value) in [("小", 0.8), ("标准", 1.0), ("大", 1.2)] {
+            let item = NSMenuItem(title: label, action: #selector(changeBubbleScale(_:)), keyEquivalent: "")
+            item.target = self
+            item.tag = Int(value * 100)
+            item.state = abs(bubbleScale - value) < 0.05 ? .on : .off
+            bubbleMenu.addItem(item)
+        }
+        let bubbleItem = NSMenuItem(title: "气泡大小", action: nil, keyEquivalent: "")
+        bubbleItem.submenu = bubbleMenu
+        menu.addItem(bubbleItem)
+
+        let reduced = NSMenuItem(title: "减少动态", action: #selector(toggleReducedMotion(_:)), keyEquivalent: "")
+        reduced.target = self
+        reduced.state = reducedMotion ? .on : .off
+        menu.addItem(reduced)
+
+        let openWeb = NSMenuItem(title: "打开 WebUI", action: #selector(openWebUI(_:)), keyEquivalent: "")
+        openWeb.target = self
+        menu.addItem(openWeb)
+
+        let accessibility = NSMenuItem(title: "辅助功能权限…", action: #selector(accessibilityPermission(_:)), keyEquivalent: "")
+        accessibility.target = self
+        menu.addItem(accessibility)
+
+        menu.addItem(.separator())
+
+        let hide = NSMenuItem(title: "本次隐藏", action: #selector(hidePet(_:)), keyEquivalent: "")
+        hide.target = self
+        menu.addItem(hide)
+
+        let quit = NSMenuItem(title: "本次关闭", action: #selector(quitFromMenu(_:)), keyEquivalent: "")
+        quit.target = self
+        menu.addItem(quit)
+
+        NSMenu.popUpContextMenu(menu, with: event, for: contentView)
+    }
+
+    @objc private func changeSize(_ sender: NSMenuItem) {
+        scale = Self.clampedScale(Double(sender.tag) / 100.0)
+        resizeAndReposition()
+        saveLayout()
+    }
+
+    @objc private func changeBubbleScale(_ sender: NSMenuItem) {
+        bubbleScale = Self.clampedBubbleScale(Double(sender.tag) / 100.0)
+        resizeAndReposition()
+        saveLayout()
+    }
+
+    @objc private func toggleReducedMotion(_ sender: NSMenuItem) {
+        reducedMotion = sender.state == .off
+        restartAnimTimer()
+        if reducedMotion {
+            microTimer?.invalidate()
+        } else {
+            scheduleMicro()
+        }
+        saveLayout()
+        contentView?.needsDisplay = true
+    }
+
+    @objc private func openWebUI(_ sender: Any?) {
+        if let url = URL(string: webuiURL) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    @objc private func accessibilityPermission(_ sender: Any?) {
+        Permissions.requestAccessibility()
+    }
+
+    @objc private func hidePet(_ sender: Any?) {
+        panel?.orderOut(nil)
+    }
+
+    @objc private func quitFromMenu(_ sender: Any?) {
+        quit(reason: "user")
+    }
+
+    // MARK: - Protocol
+
+    func apply(_ message: [String: Any]) {
+        logEvent(message)
+        guard let kind = message["kind"] as? String else { return }
+        switch kind {
+        case "shutdown":
+            quit(reason: "host")
+        case "state":
+            handleState(message)
+        case "pulse":
+            handlePulse(message)
+        case "task":
+            handleTask(message)
+        case "tasks":
+            tasks = (message["tasks"] as? [[String: Any]]) ?? []
+            resizeAndReposition()
+            contentView?.needsDisplay = true
+        case "config":
+            applyConfig(message)
+        default:
+            break
+        }
+        maybeSaveSnapshot()
+    }
+
+    private func handleState(_ message: [String: Any]) {
+        let state = Self.stringValue(message["state"]) ?? "IDLE"
+        let activity = Self.stringValue(message["activity"])
+        displayState = state
+        model.applyState(state, activity: activity)
+        clearOverlay()
+        showStatus(
+            Self.stringValue(message["message"]) ?? Self.labels[state] ?? state,
+            Self.stringValue(message["detail"]) ?? "",
+            state,
+            Self.persistentStates.contains(state) ? nil : 4200
+        )
+        contentView?.needsDisplay = true
+    }
+
+    private func handlePulse(_ message: [String: Any]) {
+        let state = Self.stringValue(message["state"]) ?? "IDLE"
+        let ttl = max(250, Self.intValue(message["ttlMs"]) ?? 1800)
+        let resumeState = Self.stringValue(message["resumeState"]) ?? model.baseState
+        let resumeActivity = Self.stringValue(message["resumeActivity"])
+        model.applyPulse(
+            state: state,
+            ttlMs: ttl,
+            nowMs: Self.nowMs(),
+            resumeState: resumeState,
+            resumeActivity: resumeActivity
+        )
+        showStatus(
+            Self.stringValue(message["resumeMessage"]) ?? Self.labels[resumeState] ?? resumeState,
+            Self.stringValue(message["resumeDetail"]) ?? "",
+            resumeState,
+            Self.persistentStates.contains(resumeState) ? nil : ttl + 2200
+        )
+        showOverlay(
+            Self.stringValue(message["message"]) ?? Self.labels[state] ?? state,
+            Self.stringValue(message["detail"]) ?? "",
+            state,
+            ttl
+        )
+        if state == "SUCCESS" || state == "ERROR" {
+            notifyAlert(state)
+        }
+        contentView?.needsDisplay = true
+    }
+
+    private func handleTask(_ message: [String: Any]) {
+        task = Self.stringValue(message["task"]) ?? ""
+        showStatus(
+            Self.stringValue(message["message"]) ?? task,
+            Self.stringValue(message["detail"]) ?? "",
+            model.baseState,
+            Self.persistentStates.contains(model.baseState) ? nil : 6000
+        )
+        contentView?.needsDisplay = true
+    }
+
+    private func applyConfig(_ message: [String: Any]) {
+        var changed = false
+        if let value = Self.doubleValue(message["scale"]), value != scale {
+            scale = Self.clampedScale(value)
+            changed = true
+        }
+        if let value = Self.doubleValue(message["bubbleScale"]), value != bubbleScale {
+            bubbleScale = Self.clampedBubbleScale(value)
+            changed = true
+        }
+        if let value = message["reducedMotion"] as? Bool, value != reducedMotion {
+            reducedMotion = value
+            restartAnimTimer()
+            if reducedMotion {
+                microTimer?.invalidate()
+            } else {
+                scheduleMicro()
+            }
+            changed = true
+        }
+        if let value = message["activityLevel"] as? String, ["quiet", "normal", "lively"].contains(value) {
+            activityLevel = value
+            if !reducedMotion {
+                scheduleMicro()
+            }
+        }
+        if changed {
+            resizeAndReposition()
+            saveLayout()
+        }
+    }
+
+    func quit(reason: String) {
+        guard !quitting else { return }
+        quitting = true
+        saveLayout()
+        animTimer?.invalidate()
+        keepFrontTimer?.invalidate()
+        microTimer?.invalidate()
+        shakeTimer?.invalidate()
+        ProtocolIO.shared.write([
+            "protocolVersion": 1,
+            "kind": "closed",
+            "reason": reason,
+            "timestamp": Self.nowMs(),
+        ])
+        panel?.close()
+        NSApp.terminate(nil)
+    }
+
+    // MARK: - Status helpers
+
+    private func showStatus(_ message: String, _ detail: String, _ state: String, _ ttlMs: Int?) {
+        statusMessage = message
+        statusDetail = detail
+        statusState = state
+        statusDeadlineMs = ttlMs.map { Self.nowMs() + $0 }
+    }
+
+    private func showOverlay(_ message: String, _ detail: String, _ state: String, _ ttlMs: Int) {
+        overlayMessage = message
+        overlayDetail = detail.isEmpty ? statusDetail : detail
+        overlayState = state
+        overlayDeadlineMs = Self.nowMs() + ttlMs
+    }
+
+    private func clearOverlay() {
+        overlayMessage = ""
+        overlayDetail = ""
+        overlayState = nil
+        overlayDeadlineMs = nil
+    }
+
+    func currentCard() -> (title: String, detail: String, state: String)? {
+        let now = Self.nowMs()
+        if !overlayMessage.isEmpty, overlayDeadlineMs == nil || now < overlayDeadlineMs! {
+            return (overlayMessage, overlayDetail, overlayState ?? statusState)
+        }
+        if !statusMessage.isEmpty, statusDeadlineMs == nil || now < statusDeadlineMs! {
+            return (statusMessage, statusDetail, statusState)
+        }
+        return nil
+    }
+
+    private func notifyAlert(_ state: String) {
+        NSSound.beep()
+        shakeWindow()
+        Permissions.requestNotificationAuthorizationIfNeeded()
+        guard Bundle.main.bundleIdentifier != nil else { return }
+        let content = UNMutableNotificationContent()
+        content.title = state == "SUCCESS" ? "任务完成" : "任务出错"
+        content.body = state == "SUCCESS" ? "DSH 任务已完成" : "DSH 任务遇到问题"
+        content.sound = .default
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                FileHandle.standardError.write(Data("Notification error: \(error)\n".utf8))
+            }
+        }
+    }
+
+    private func shakeWindow() {
+        guard let panel = panel else { return }
+        shakeTimer?.invalidate()
+        shakeOrigin = panel.frame.origin
+        shakeCount = 0
+        shakeTimer = Timer.scheduledTimer(withTimeInterval: 0.03, repeats: true) { [weak self] _ in
+            self?.shakeTick()
+        }
+    }
+
+    private func shakeTick() {
+        guard let panel = panel, let origin = shakeOrigin else {
+            shakeTimer?.invalidate()
+            shakeTimer = nil
+            return
+        }
+        let offsets: [(CGFloat, CGFloat)] = [(6, 0), (-6, 0), (4, 0), (-4, 0), (2, 0), (-2, 0), (0, 0)]
+        if shakeCount < offsets.count {
+            let offset = offsets[shakeCount]
+            panel.setFrameOrigin(NSPoint(x: origin.x + offset.0, y: origin.y + offset.1))
+            shakeCount += 1
+        } else {
+            shakeTimer?.invalidate()
+            shakeTimer = nil
+            panel.setFrameOrigin(origin)
+        }
+    }
+
+    private func restartAnimTimer() {
+        lastTickMs = Self.nowMs()
+        startAnimTimer()
+    }
+
+    // MARK: - Drawing
+
+    func drawPet(in view: NSView) {
+        guard let image = frames[model.frame] else { return }
+        let phase = CACurrentMediaTime()
+        var motion = model.activeClip.motion
+        if reducedMotion {
+            motion = nil
+        }
+        var scaleExtra: CGFloat = 1
+        var angle: CGFloat = 0
+        var offsetX: CGFloat = 0
+        var offsetY: CGFloat = 0
+        let clipName = model.activeClipName
+
+        switch motion {
+        case "breathe":
+            scaleExtra = 1 + 0.02 * CGFloat(sin(phase * 2.5))
+            angle = CGFloat(sin(phase * 2.5)) * 1.5
+        case "think":
+            offsetY = CGFloat(sin(phase * 2.8)) * 3
+            angle = CGFloat(sin(phase * 1.3)) * 0.8
+        case "work":
+            offsetX = CGFloat(sin(phase * 5.4)) * 3
+            angle = CGFloat(sin(phase * 3.1)) * 1.0
+        case "wait":
+            offsetY = CGFloat(sin(phase * 1.8)) * 1
+            angle = CGFloat(sin(phase * 1.2)) * 0.8
+        case "bounce":
+            offsetY = -abs(CGFloat(sin(phase * 5.2))) * 8
+            scaleExtra = 1 + 0.02 * CGFloat(sin(phase * 5.2))
+        case "shake", "dizzy":
+            offsetX = CGFloat(sin(phase * 11.0)) * 4
+            angle = CGFloat(sin(phase * 11.0)) * 1.5
+        case "float":
+            offsetY = CGFloat(sin(phase * 3.0)) * 4
+            angle = CGFloat(sin(phase * 1.6)) * 1.0
+        default:
+            break
+        }
+        if clipName == "working_search" || clipName == "working_command" {
+            offsetY = -abs(CGFloat(sin(phase * 4.5))) * 5
+            angle = CGFloat(sin(phase * 9.0)) * 2.5
+        }
+        offsetX *= scale
+        offsetY *= scale
+
+        var fadeAlpha: CGFloat = 1
+        var fadeImage: NSImage?
+        if let fromFrame = fadeFromFrame, let fromImage = frames[fromFrame] {
+            let elapsed = CACurrentMediaTime() - fadeStarted
+            if elapsed < fadeDuration {
+                fadeAlpha = min(1, pow(CGFloat(elapsed / fadeDuration), 0.7))
+                fadeImage = fromImage
+            } else {
+                fadeFromFrame = nil
+            }
+        }
+
+        let pet = petRect()
+        let baseWidth = pet.width
+        let baseHeight = pet.height
+        let drawWidth = baseWidth * scaleExtra
+        let drawHeight = baseHeight * scaleExtra
+        let x = pet.minX + (baseWidth - drawWidth) / 2 + offsetX
+        var y = pet.minY + (baseHeight - drawHeight) / 2 + offsetY
+        let card = bubbleRect()
+        let bubbleBottom = card.maxY + 12
+        if bubbleBottom > y {
+            y = bubbleBottom
+        }
+        let centerX = x + drawWidth / 2
+        let centerY = y + drawHeight / 2
+
+        func draw(_ img: NSImage, alpha: CGFloat) {
+            NSGraphicsContext.saveGraphicsState()
+            guard let ctx = NSGraphicsContext.current?.cgContext else {
+                NSGraphicsContext.restoreGraphicsState()
+                return
+            }
+            ctx.saveGState()
+            ctx.translateBy(x: centerX, y: centerY)
+            if angle != 0 {
+                ctx.rotate(by: angle * .pi / 180)
+            }
+            // The content view is flipped (top-left origin). NSImage drawing
+            // does not compensate for a flipped context, which would render
+            // the pet vertically mirrored. Mirror about the image's own
+            // center so it draws right-side up while staying in place.
+            ctx.scaleBy(x: 1, y: -1)
+            img.draw(
+                in: NSRect(x: -drawWidth / 2, y: -drawHeight / 2, width: drawWidth, height: drawHeight),
+                from: NSRect(origin: .zero, size: img.size),
+                operation: .sourceOver,
+                fraction: alpha
+            )
+            ctx.restoreGState()
+            NSGraphicsContext.restoreGraphicsState()
+        }
+
+        if fadeAlpha < 1, let fadeImage = fadeImage {
+            draw(fadeImage, alpha: 1)
+        }
+        draw(image, alpha: fadeAlpha)
+    }
+
+    func drawCard(in view: NSView) {
+        let rect = bubbleRect()
+        if tasks.count >= 2 {
+            drawTaskCard(rect: rect)
+        } else if let card = currentCard() {
+            drawStatusCard(rect: rect, card: card)
+        }
+    }
+
+    private func drawStatusCard(rect: NSRect, card: (title: String, detail: String, state: String)) {
+        let s = bubbleScale
+        let corner: CGFloat = 16 * s
+        let shadow1 = NSRect(x: rect.minX + 1, y: rect.minY + 6, width: rect.width - 2, height: rect.height)
+        let shadow2 = NSRect(x: rect.minX, y: rect.minY + 3, width: rect.width, height: rect.height)
+        NSColor(calibratedWhite: 0.05, alpha: 0.05).setFill()
+        NSBezierPath(roundedRect: shadow1, xRadius: corner, yRadius: corner).fill()
+        NSColor(calibratedWhite: 0.08, alpha: 0.08).setFill()
+        NSBezierPath(roundedRect: shadow2, xRadius: corner, yRadius: corner).fill()
+
+        let cardPath = NSBezierPath(roundedRect: rect, xRadius: corner, yRadius: corner)
+        NSColor(calibratedRed: 0.988, green: 0.988, blue: 0.992, alpha: 0.97).setFill()
+        cardPath.fill()
+        NSColor(calibratedWhite: 0.85, alpha: 0.8).setStroke()
+        cardPath.lineWidth = 1
+        cardPath.stroke()
+
+        let iconCenter = NSPoint(x: rect.maxX - 34 * s, y: rect.midY)
+        drawStatusIcon(center: iconCenter, state: card.state, scale: s)
+
+        let textX = rect.minX + 16 * s
+        let textWidth = max(40, rect.width - 102 * s)
+        let titleFont = NSFont.systemFont(ofSize: max(8.0, 11.0 * s), weight: .semibold)
+        let detailFont = NSFont.systemFont(ofSize: max(7.0, 9.0 * s))
+        drawText(
+            card.title,
+            in: NSRect(x: textX, y: rect.minY + 15 * s, width: textWidth, height: max(12, 27 * s)),
+            font: titleFont,
+            color: Self.hex("#25282D")
+        )
+        drawText(
+            card.detail,
+            in: NSRect(x: textX, y: rect.minY + 43 * s, width: textWidth, height: max(12, 24 * s)),
+            font: detailFont,
+            color: Self.hex("#747981")
+        )
+    }
+
+    private func drawStatusIcon(center: NSPoint, state: String, scale s: CGFloat) {
+        let (bgHex, fgHex) = Self.statusColors[state] ?? ("#ECEEF1", "#747A84")
+        let radius: CGFloat = 23 * s
+        Self.hex(bgHex).setFill()
+        NSBezierPath(ovalIn: NSRect(x: center.x - radius, y: center.y - radius, width: radius * 2, height: radius * 2)).fill()
+
+        let foreground = Self.hex(fgHex)
+        let lineWidth: CGFloat = 3 * s
+        switch state {
+        case "SUCCESS":
+            strokeLine(from: NSPoint(x: center.x - 10 * s, y: center.y),
+                       to: NSPoint(x: center.x - 3 * s, y: center.y + 8 * s),
+                       width: lineWidth, color: foreground)
+            strokeLine(from: NSPoint(x: center.x - 3 * s, y: center.y + 8 * s),
+                       to: NSPoint(x: center.x + 12 * s, y: center.y - 10 * s),
+                       width: lineWidth, color: foreground)
+        case "ERROR":
+            strokeLine(from: NSPoint(x: center.x - 8 * s, y: center.y - 8 * s),
+                       to: NSPoint(x: center.x + 8 * s, y: center.y + 8 * s),
+                       width: lineWidth, color: foreground)
+            strokeLine(from: NSPoint(x: center.x + 8 * s, y: center.y - 8 * s),
+                       to: NSPoint(x: center.x - 8 * s, y: center.y + 8 * s),
+                       width: lineWidth, color: foreground)
+        case "WAITING":
+            strokeLine(from: NSPoint(x: center.x, y: center.y - 10 * s),
+                       to: NSPoint(x: center.x, y: center.y + 3 * s),
+                       width: lineWidth, color: foreground)
+            foreground.setFill()
+            NSBezierPath(ovalIn: NSRect(x: center.x - 2 * s, y: center.y + 9 * s, width: 4 * s, height: 4 * s)).fill()
+        case "THINKING", "WORKING":
+            foreground.setFill()
+            for offset in [-9.0, 0.0, 9.0] {
+                NSBezierPath(ovalIn: NSRect(x: center.x + CGFloat(offset) * s - 3 * s,
+                                            y: center.y - 3 * s,
+                                            width: 6 * s,
+                                            height: 6 * s)).fill()
+            }
+        default:
+            foreground.setFill()
+            NSBezierPath(ovalIn: NSRect(x: center.x - 5 * s, y: center.y - 5 * s, width: 10 * s, height: 10 * s)).fill()
+        }
+    }
+
+    private func drawTaskCard(rect: NSRect) {
+        let s = bubbleScale
+        let corner: CGFloat = 16 * s
+        NSColor(calibratedWhite: 0.05, alpha: 0.05).setFill()
+        NSBezierPath(roundedRect: NSRect(x: rect.minX + 1, y: rect.minY + 6, width: rect.width - 2, height: rect.height),
+                     xRadius: corner, yRadius: corner).fill()
+        let cardPath = NSBezierPath(roundedRect: rect, xRadius: corner, yRadius: corner)
+        NSColor(calibratedRed: 0.988, green: 0.988, blue: 0.992, alpha: 0.97).setFill()
+        cardPath.fill()
+        NSColor(calibratedWhite: 0.85, alpha: 0.8).setStroke()
+        cardPath.lineWidth = 1
+        cardPath.stroke()
+
+        let textX = rect.minX + 16 * s
+        let textWidth = max(40, rect.width - 32 * s)
+        let titleFont = NSFont.systemFont(ofSize: max(8.0, 11.0 * s), weight: .semibold)
+        let detailFont = NSFont.systemFont(ofSize: max(7.0, 9.0 * s))
+        drawText(
+            "\(tasks.count) 个任务进行中",
+            in: NSRect(x: textX, y: rect.minY + 10 * s, width: textWidth, height: max(12, 22 * s)),
+            font: titleFont,
+            color: Self.hex("#25282D")
+        )
+
+        for (index, task) in tasks.prefix(3).enumerated() {
+            let rowY = rect.minY + (36 + CGFloat(index) * 24) * s
+            let state = Self.stringValue(task["state"]) ?? "IDLE"
+            let stateLabel = Self.labels[state] ?? state
+            let label = Self.stringValue(task["project"])
+                ?? Self.stringValue(task["task"])
+                ?? Self.stringValue(task["message"])
+                ?? stateLabel
+            let line = "\(stateLabel) · \(label)"
+            let (_, fgHex) = Self.statusColors[state] ?? ("#ECEEF1", "#747A84")
+            Self.hex(fgHex).setFill()
+            NSBezierPath(ovalIn: NSRect(x: textX, y: rowY + 4 * s, width: 8 * s, height: 8 * s)).fill()
+            drawText(
+                line,
+                in: NSRect(x: textX + 14 * s, y: rowY, width: textWidth - 14 * s, height: max(12, 20 * s)),
+                font: detailFont,
+                color: Self.hex("#747981")
+            )
+        }
+        if tasks.count > 3 {
+            drawText(
+                "还有 \(tasks.count - 3) 个任务…",
+                in: NSRect(x: textX + 14 * s, y: rect.minY + (36 + 3 * 24) * s,
+                           width: textWidth, height: max(12, 20 * s)),
+                font: detailFont,
+                color: Self.hex("#9AA0A6")
+            )
+        }
+    }
+
+    private func drawText(_ text: String, in rect: NSRect, font: NSFont, color: NSColor) {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineBreakMode = .byTruncatingTail
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: color,
+            .paragraphStyle: paragraph,
+        ]
+        (text as NSString).draw(in: rect, withAttributes: attributes)
+    }
+
+    private func strokeLine(from: NSPoint, to: NSPoint, width: CGFloat, color: NSColor) {
+        color.setStroke()
+        let path = NSBezierPath()
+        path.lineWidth = width
+        path.lineCapStyle = .round
+        path.move(to: from)
+        path.line(to: to)
+        path.stroke()
+    }
+
+    // MARK: - Misc
+
+    private func maybeSaveSnapshot() {
+        guard let snapshotURL = snapshotURL, !snapshotSaved, !isHeadless() else { return }
+        snapshotSaved = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) { [weak self] in
+            guard let self = self, let view = self.contentView else { return }
+            if let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) {
+                view.cacheDisplay(in: view.bounds, to: rep)
+                if let data = rep.representation(using: .png, properties: [:]) {
+                    try? data.write(to: snapshotURL)
+                }
+            }
+        }
+    }
+
+    private func logEvent(_ message: [String: Any]) {
+        guard let eventLogURL = eventLogURL,
+              let data = try? JSONSerialization.data(withJSONObject: message),
+              let line = String(data: data, encoding: .utf8) else { return }
+        let payload = Data((line + "\n").utf8)
+        if let handle = try? FileHandle(forWritingTo: eventLogURL) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: payload)
+        } else {
+            try? payload.write(to: eventLogURL)
+        }
+    }
+
+    static func clampedScale(_ value: Double) -> Double {
+        min(1.4, max(0.7, value))
+    }
+
+    static func clampedBubbleScale(_ value: Double) -> Double {
+        min(1.2, max(0.8, value))
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        if let string = value as? String { return string }
+        if let number = value as? NSNumber { return number.stringValue }
+        return nil
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let int = value as? Int { return int }
+        if let double = value as? Double { return Int(double) }
+        if let string = value as? String { return Int(string) }
+        return nil
+    }
+
+    private static func doubleValue(_ value: Any?) -> Double? {
+        if let double = value as? Double { return double }
+        if let int = value as? Int { return Double(int) }
+        if let string = value as? String { return Double(string) }
+        return nil
+    }
+
+    private static func nowMs() -> Int {
+        Int(CACurrentMediaTime() * 1000)
+    }
+
+    private static func hex(_ hex: String) -> NSColor {
+        let value = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        if value.count == 6 {
+            let red = Double(Int(value.prefix(2), radix: 16) ?? 0) / 255
+            let green = Double(Int(value.dropFirst(2).prefix(2), radix: 16) ?? 0) / 255
+            let blue = Double(Int(value.dropFirst(4).prefix(2), radix: 16) ?? 0) / 255
+            return NSColor(calibratedRed: red, green: green, blue: blue, alpha: 1)
+        }
+        return .gray
+    }
+}

--- a/native/macos/Sources/PetView.swift
+++ b/native/macos/Sources/PetView.swift
@@ -1,0 +1,65 @@
+import AppKit
+
+/// Content view: draws the pet + status card and handles mouse interactions.
+/// Uses a flipped coordinate system (top-left origin) to match the original
+/// Qt helper's drawing math.
+final class PetView: NSView {
+    weak var controller: PetController?
+
+    /// Mouse-to-window grab offset, captured at mouseDown, used for 1:1 drag.
+    private var grabOffset: NSPoint?
+    private var windowOrigin: NSPoint?
+
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let window = window else { return }
+        windowOrigin = window.frame.origin
+        let mouse = NSEvent.mouseLocation
+        grabOffset = NSPoint(x: mouse.x - window.frame.origin.x,
+                             y: mouse.y - window.frame.origin.y)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let grabOffset = grabOffset,
+              let windowOrigin = windowOrigin,
+              let window = window else { return }
+        // Use absolute screen coordinates so the drag tracks the cursor 1:1.
+        // View-relative deltas would fight the moving window and feel laggy.
+        let mouse = NSEvent.mouseLocation
+        let newOrigin = NSPoint(x: mouse.x - grabOffset.x,
+                                y: mouse.y - grabOffset.y)
+        if !(controller?.dragging ?? false) {
+            let manhattan = abs(newOrigin.x - windowOrigin.x)
+                + abs(newOrigin.y - windowOrigin.y)
+            if manhattan <= 5 { return }
+            controller?.beginDrag()
+        }
+        window.setFrameOrigin(newOrigin)
+        controller?.updateDrag()
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        let clickCount = event.clickCount
+        let wasDragging = controller?.dragging ?? false
+        grabOffset = nil
+        windowOrigin = nil
+        if wasDragging {
+            controller?.endDrag()
+        } else {
+            controller?.handleClick(at: point, clickCount: clickCount)
+        }
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        controller?.showMenu(with: event)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let controller = controller else { return }
+        controller.drawPet(in: self)
+        controller.drawCard(in: self)
+    }
+}

--- a/native/macos/Sources/main.swift
+++ b/native/macos/Sources/main.swift
@@ -1,0 +1,176 @@
+import AppKit
+import QuartzCore
+
+/// Serialized stdout writer for the newline-delimited JSON protocol.
+final class ProtocolIO {
+    static let shared = ProtocolIO()
+    private let lock = NSLock()
+
+    func write(_ object: [String: Any]) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let data = try? JSONSerialization.data(withJSONObject: object) else { return }
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+        try? FileHandle.standardOutput.synchronize()
+    }
+}
+
+private func currentTimestamp() -> Int {
+    Int(CACurrentMediaTime() * 1000)
+}
+
+private func loadManifest(at root: URL) -> [String: Any]? {
+    let manifestURL = root.appendingPathComponent("pet-manifest.json")
+    guard let data = try? Data(contentsOf: manifestURL),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return nil
+    }
+    return json
+}
+
+private func locateAssets() -> (manifest: [String: Any], assetRoot: URL)? {
+    if let env = ProcessInfo.processInfo.environment["DSH_DAFEIYU_ASSET_ROOT"] {
+        let root = URL(fileURLWithPath: env)
+        if let manifest = loadManifest(at: root) {
+            return (manifest, root.appendingPathComponent("pet"))
+        }
+    }
+    if let bundleAssets = Bundle.main.resourceURL?.appendingPathComponent("assets"),
+       let manifest = loadManifest(at: bundleAssets) {
+        return (manifest, bundleAssets.appendingPathComponent("pet"))
+    }
+    let candidate = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".dsh/profiles/web/node_modules/dsh-dafeiyu/assets")
+    if let manifest = loadManifest(at: candidate) {
+        return (manifest, candidate.appendingPathComponent("pet"))
+    }
+    return nil
+}
+
+private func appendEventLog(_ message: [String: Any], to url: URL?) {
+    guard let url = url,
+          let data = try? JSONSerialization.data(withJSONObject: message),
+          let line = String(data: data, encoding: .utf8) else { return }
+    let payload = Data((line + "\n").utf8)
+    if let handle = try? FileHandle(forWritingTo: url) {
+        defer { try? handle.close() }
+        _ = try? handle.seekToEnd()
+        try? handle.write(contentsOf: payload)
+    } else {
+        try? payload.write(to: url)
+    }
+}
+
+// ---- Argument parsing: --headless, --event-log <path>, --snapshot <path> ----
+var arguments = Array(CommandLine.arguments.dropFirst())
+var headless = false
+var eventLogURL: URL?
+var snapshotURL: URL?
+while !arguments.isEmpty {
+    let arg = arguments.removeFirst()
+    switch arg {
+    case "--headless":
+        headless = true
+    case "--event-log":
+        if !arguments.isEmpty {
+            eventLogURL = URL(fileURLWithPath: arguments.removeFirst())
+        }
+    case "--snapshot":
+        if !arguments.isEmpty {
+            snapshotURL = URL(fileURLWithPath: arguments.removeFirst())
+        }
+    default:
+        break
+    }
+}
+
+guard let assets = locateAssets() else {
+    FileHandle.standardError.write(Data("Unable to locate BigFish assets\n".utf8))
+    exit(2)
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+
+let environment = ProcessInfo.processInfo.environment
+let webuiURL = environment["DSH_DAFEIYU_WEBUI_URL"] ?? "http://127.0.0.1:3080/"
+let model = AnimationModel(manifest: assets.manifest)
+
+if headless {
+    ProtocolIO.shared.write([
+        "protocolVersion": 1,
+        "kind": "ready",
+        "timestamp": currentTimestamp(),
+    ])
+    while let line = readLine() {
+        guard !line.isEmpty else { continue }
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            ProtocolIO.shared.write([
+                "protocolVersion": 1,
+                "kind": "error",
+                "message": "invalid json",
+            ])
+            continue
+        }
+        appendEventLog(object, to: eventLogURL)
+        if (object["kind"] as? String) == "ping" {
+            ProtocolIO.shared.write([
+                "protocolVersion": 1,
+                "kind": "pong",
+                "timestamp": currentTimestamp(),
+            ])
+        }
+        if (object["kind"] as? String) == "shutdown" {
+            break
+        }
+    }
+    exit(0)
+}
+
+let controller = PetController(
+    model: model,
+    manifest: assets.manifest,
+    assetRoot: assets.assetRoot,
+    layoutURL: PetLayout.defaultPath(),
+    webuiURL: webuiURL,
+    eventLogURL: eventLogURL,
+    snapshotURL: snapshotURL
+)
+controller.show()
+
+ProtocolIO.shared.write([
+    "protocolVersion": 1,
+    "kind": "ready",
+    "timestamp": currentTimestamp(),
+])
+
+let stdinQueue = DispatchQueue(label: "dsh-dafeiyu.stdin")
+stdinQueue.async {
+    while let line = readLine() {
+        guard !line.isEmpty else { continue }
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            ProtocolIO.shared.write([
+                "protocolVersion": 1,
+                "kind": "error",
+                "message": "invalid json",
+            ])
+            continue
+        }
+        if (object["kind"] as? String) == "ping" {
+            ProtocolIO.shared.write([
+                "protocolVersion": 1,
+                "kind": "pong",
+                "timestamp": currentTimestamp(),
+            ])
+        }
+        DispatchQueue.main.async {
+            controller.apply(object)
+        }
+    }
+}
+
+app.run()
+exit(0)

--- a/native/macos/Sources/main.swift
+++ b/native/macos/Sources/main.swift
@@ -1,5 +1,8 @@
 import AppKit
+import Darwin
 import QuartzCore
+
+signal(SIGPIPE, SIG_IGN)
 
 /// Serialized stdout writer for the newline-delimited JSON protocol.
 final class ProtocolIO {
@@ -10,14 +13,14 @@ final class ProtocolIO {
         lock.lock()
         defer { lock.unlock() }
         guard let data = try? JSONSerialization.data(withJSONObject: object) else { return }
-        FileHandle.standardOutput.write(data)
-        FileHandle.standardOutput.write(Data("\n".utf8))
+        try? FileHandle.standardOutput.write(contentsOf: data)
+        try? FileHandle.standardOutput.write(contentsOf: Data("\n".utf8))
         try? FileHandle.standardOutput.synchronize()
     }
 }
 
 private func currentTimestamp() -> Int {
-    Int(CACurrentMediaTime() * 1000)
+    Int(Date().timeIntervalSince1970 * 1000)
 }
 
 private func loadManifest(at root: URL) -> [String: Any]? {
@@ -106,7 +109,8 @@ if headless {
     while let line = readLine() {
         guard !line.isEmpty else { continue }
         guard let data = line.data(using: .utf8),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (object["protocolVersion"] as? Int) == 1 else {
             ProtocolIO.shared.write([
                 "protocolVersion": 1,
                 "kind": "error",
@@ -151,7 +155,8 @@ stdinQueue.async {
     while let line = readLine() {
         guard !line.isEmpty else { continue }
         guard let data = line.data(using: .utf8),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (object["protocolVersion"] as? Int) == 1 else {
             ProtocolIO.shared.write([
                 "protocolVersion": 1,
                 "kind": "error",
@@ -169,6 +174,9 @@ stdinQueue.async {
         DispatchQueue.main.async {
             controller.apply(object)
         }
+    }
+    DispatchQueue.main.async {
+        controller.quit(reason: "stdin-eof", reportClosed: false)
     }
 }
 

--- a/native/macos/build.sh
+++ b/native/macos/build.sh
@@ -42,7 +42,7 @@ swiftc -O -swift-version 5 -target x86_64-apple-macosx12.0 \
 lipo -create "$WORK/helper-arm64" "$WORK/helper-x86_64" -output "$BIN"
 chmod 0755 "$BIN"
 codesign --force --deep --sign - --timestamp=none "$APP"
-lipo -verify_arch arm64 x86_64 "$BIN"
+lipo "$BIN" -verify_arch arm64 x86_64
 plutil -lint "$APP/Contents/Info.plist"
 codesign --verify --deep --strict --verbose=2 "$APP"
 

--- a/native/macos/build.sh
+++ b/native/macos/build.sh
@@ -8,9 +8,13 @@ BIN="$APP/Contents/MacOS/dsh-dafeiyu-helper"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
+rm -rf "$APP"
 mkdir -p "$(dirname "$BIN")" "$APP/Contents/Resources"
 cp "$DIR/Info.plist" "$APP/Contents/Info.plist"
 cp -R "$ROOT/assets" "$APP/Contents/Resources/assets"
+PACKAGE_VERSION="$(node -p "require('$ROOT/package.json').version")"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $PACKAGE_VERSION" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $PACKAGE_VERSION" "$APP/Contents/Info.plist"
 
 SOURCES=(
   "$DIR/Sources/AnimationModel.swift" \
@@ -36,6 +40,10 @@ swiftc -O -swift-version 5 -target x86_64-apple-macosx12.0 \
   "${SOURCES[@]}" "${FRAMEWORKS[@]}" -o "$WORK/helper-x86_64"
 
 lipo -create "$WORK/helper-arm64" "$WORK/helper-x86_64" -output "$BIN"
-codesign --force --deep -s - "$APP" 2>/dev/null
+chmod 0755 "$BIN"
+codesign --force --deep --sign - --timestamp=none "$APP"
+lipo -verify_arch arm64 x86_64 "$BIN"
+plutil -lint "$APP/Contents/Info.plist"
+codesign --verify --deep --strict --verbose=2 "$APP"
 
 echo "built universal macOS helper (arm64 + x86_64, macOS 12+): $APP"

--- a/native/macos/build.sh
+++ b/native/macos/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+APP="$ROOT/runtime/bin/darwin/dsh-dafeiyu-helper.app"
+BIN="$APP/Contents/MacOS/dsh-dafeiyu-helper"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$(dirname "$BIN")" "$APP/Contents/Resources"
+cp "$DIR/Info.plist" "$APP/Contents/Info.plist"
+cp -R "$ROOT/assets" "$APP/Contents/Resources/assets"
+
+SOURCES=(
+  "$DIR/Sources/AnimationModel.swift" \
+  "$DIR/Sources/LayoutStore.swift" \
+  "$DIR/Sources/Permissions.swift" \
+  "$DIR/Sources/PetController.swift" \
+  "$DIR/Sources/PetView.swift" \
+  "$DIR/Sources/main.swift" \
+)
+FRAMEWORKS=(
+  -framework AppKit \
+  -framework UserNotifications \
+  -framework ApplicationServices \
+  -framework QuartzCore \
+)
+
+echo "building arm64 slice (macOS 12+)..."
+swiftc -O -swift-version 5 -target arm64-apple-macosx12.0 \
+  "${SOURCES[@]}" "${FRAMEWORKS[@]}" -o "$WORK/helper-arm64"
+
+echo "building x86_64 slice (macOS 12+)..."
+swiftc -O -swift-version 5 -target x86_64-apple-macosx12.0 \
+  "${SOURCES[@]}" "${FRAMEWORKS[@]}" -o "$WORK/helper-x86_64"
+
+lipo -create "$WORK/helper-arm64" "$WORK/helper-x86_64" -output "$BIN"
+codesign --force --deep -s - "$APP" 2>/dev/null
+
+echo "built universal macOS helper (arm64 + x86_64, macOS 12+): $APP"

--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
     "ASSET_LICENSE.md",
     "LICENSE"
   ],
-  "cpu": [
-    "x64"
-  ],
   "engines": {
     "node": ">=22.19"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "runtime/layout_store.py",
     "runtime/__init__.py",
     "runtime/bin/",
+    "native/macos/",
     "scripts/build-helper.ps1",
     "scripts/build-helper.sh",
     "scripts/build-helper.mjs",
@@ -54,6 +55,7 @@
     "build:helper": "node scripts/build-helper.mjs",
     "build:helper:windows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-helper.ps1",
     "build:helper:linux": "bash scripts/build-helper.sh",
+    "build:helper:darwin": "bash native/macos/build.sh",
     "test:helper:packaged": "node scripts/test-packaged-helper.mjs"
   },
   "dsh": {

--- a/scripts/build-helper.mjs
+++ b/scripts/build-helper.mjs
@@ -10,6 +10,8 @@ const launch = process.platform === 'win32'
     }
   : process.platform === 'linux'
     ? { command: 'bash', args: [resolve(root, 'scripts', 'build-helper.sh')] }
+    : process.platform === 'darwin'
+      ? { command: 'bash', args: [resolve(root, 'native', 'macos', 'build.sh')] }
     : undefined
 
 if (!launch) {

--- a/scripts/test-packaged-helper.mjs
+++ b/scripts/test-packaged-helper.mjs
@@ -14,11 +14,21 @@ const executable = resolve(argument('--executable')
     projectRoot,
     process.platform === 'win32'
       ? 'runtime/bin/win32-x64/dsh-dafeiyu-helper.exe'
-      : 'runtime/bin/linux-x64/dsh-dafeiyu-helper',
+      : process.platform === 'darwin'
+        ? 'runtime/bin/darwin/dsh-dafeiyu-helper.app/Contents/MacOS/dsh-dafeiyu-helper'
+        : 'runtime/bin/linux-x64/dsh-dafeiyu-helper',
   ))
 const snapshot = resolve(argument('--snapshot')
   ?? resolve(projectRoot, '.build/helper/packaged-visual-smoke.png'))
 const timeoutMs = Number(argument('--timeout-ms') ?? 15_000)
+const hasReply = (output, kind) => output.split(/\r?\n/).some((line) => {
+  if (!line.trim()) return false
+  try {
+    return JSON.parse(line).kind === kind
+  } catch {
+    return false
+  }
+})
 
 await stat(executable)
 await mkdir(dirname(snapshot), { recursive: true })
@@ -52,7 +62,7 @@ const waitUntil = async (predicate, label) => {
 }
 
 try {
-  await waitUntil(() => standardOutput.includes('"kind": "ready"'), 'ready handshake')
+  await waitUntil(() => hasReply(standardOutput, 'ready'), 'ready handshake')
   child.stdin.write(`${JSON.stringify({
     protocolVersion: 1,
     kind: 'state',
@@ -99,3 +109,41 @@ try {
   if (child.exitCode === null) child.kill()
   throw error
 }
+
+const eofChild = spawn(executable, ['--headless'], {
+  stdio: ['pipe', 'pipe', 'pipe'],
+  windowsHide: true,
+})
+let eofOutput = ''
+let eofError = ''
+eofChild.stdout.setEncoding('utf8')
+eofChild.stderr.setEncoding('utf8')
+eofChild.stdout.on('data', (chunk) => { eofOutput += chunk })
+eofChild.stderr.on('data', (chunk) => { eofError += chunk })
+const eofExit = new Promise((resolveExit) => {
+  eofChild.once('exit', (code, signal) => resolveExit({ code, signal }))
+})
+const eofDeadline = Date.now() + timeoutMs
+while (!hasReply(eofOutput, 'ready') && Date.now() < eofDeadline) {
+  if (eofChild.exitCode !== null) {
+    throw new Error(`headless helper exited before ready with code ${eofChild.exitCode}. ${eofError}`)
+  }
+  await delay(50)
+}
+if (!hasReply(eofOutput, 'ready')) {
+  eofChild.kill()
+  throw new Error(`headless ready handshake timed out. stdout=${eofOutput} stderr=${eofError}`)
+}
+eofChild.stdin.end()
+const eofResult = await Promise.race([
+  eofExit,
+  delay(5_000).then(() => ({ timeout: true })),
+])
+if (eofResult.timeout) {
+  eofChild.kill()
+  throw new Error('headless helper did not exit after stdin EOF')
+}
+if (eofResult.code !== 0) {
+  throw new Error(`headless helper exited with code ${eofResult.code}. ${eofError}`)
+}
+console.log('Packaged helper stdin-EOF lifecycle test passed')

--- a/src/helper-process.js
+++ b/src/helper-process.js
@@ -81,7 +81,7 @@ function resolveHelperLaunch({
   windowsPath = toWindowsPath,
   cmdExe = defaultCmdExe,
 }) {
-  if (platform === 'win32' && fileExists(bundledPath)) {
+  if ((platform === 'win32' || platform === 'darwin') && fileExists(bundledPath)) {
     return { command: bundledPath, args: [] }
   }
   if (platform === 'linux' && isWslEnv && !headless && fileExists(bundledPath)) {

--- a/src/helper-process.js
+++ b/src/helper-process.js
@@ -13,6 +13,17 @@ const here = dirname(fileURLToPath(import.meta.url))
 const defaultHelperPath = resolve(here, '..', 'runtime', 'helper.py')
 const bundledHelperPath = resolve(here, '..', 'runtime', 'bin', 'win32-x64', 'dsh-dafeiyu-helper.exe')
 const linuxBundledHelperPath = resolve(here, '..', 'runtime', 'bin', 'linux-x64', 'dsh-dafeiyu-helper')
+const darwinBundledHelperPath = resolve(
+  here,
+  '..',
+  'runtime',
+  'bin',
+  'darwin',
+  'dsh-dafeiyu-helper.app',
+  'Contents',
+  'MacOS',
+  'dsh-dafeiyu-helper',
+)
 
 function isWsl() {
   if (process.platform !== 'linux') return false
@@ -29,7 +40,8 @@ function isWsl() {
 
 function shouldUseBundledHelper() {
   if (process.platform === 'win32' || isWsl()) return existsSync(bundledHelperPath)
-  return process.platform === 'linux' && existsSync(linuxBundledHelperPath)
+  if (process.platform === 'linux') return existsSync(linuxBundledHelperPath)
+  return process.platform === 'darwin' && existsSync(darwinBundledHelperPath)
 }
 
 function isBundledHelperCommand(command) {
@@ -74,6 +86,7 @@ function resolveHelperLaunch({
   isWslEnv,
   bundledPath,
   linuxBundledPath = linuxBundledHelperPath,
+  darwinBundledPath = darwinBundledHelperPath,
   helperPath,
   pythonEnv,
   headless = false,
@@ -81,8 +94,11 @@ function resolveHelperLaunch({
   windowsPath = toWindowsPath,
   cmdExe = defaultCmdExe,
 }) {
-  if ((platform === 'win32' || platform === 'darwin') && fileExists(bundledPath)) {
+  if (platform === 'win32' && fileExists(bundledPath)) {
     return { command: bundledPath, args: [] }
+  }
+  if (platform === 'darwin' && fileExists(darwinBundledPath)) {
+    return { command: darwinBundledPath, args: [] }
   }
   if (platform === 'linux' && isWslEnv && !headless && fileExists(bundledPath)) {
     // npm archives created on Windows store ordinary files as 0644. Launching
@@ -107,6 +123,7 @@ function defaultLaunch(headless = false) {
     isWslEnv: isWsl(),
     bundledPath: bundledHelperPath,
     linuxBundledPath: linuxBundledHelperPath,
+    darwinBundledPath: darwinBundledHelperPath,
     helperPath: defaultHelperPath,
     pythonEnv: process.env.DSH_DAFEIYU_PYTHON,
     headless,
@@ -383,6 +400,7 @@ export class HelperProcess {
 
 export {
   bundledHelperPath,
+  darwinBundledHelperPath,
   linuxBundledHelperPath,
   defaultHelperPath,
   defaultArgs,

--- a/test/helper-command.test.js
+++ b/test/helper-command.test.js
@@ -4,6 +4,7 @@ import { defaultCmdExe, resolveHelperLaunch } from '../src/helper-process.js'
 
 const bundledPath = '/package/runtime/bin/win32-x64/dsh-dafeiyu-helper.exe'
 const linuxBundledPath = '/package/runtime/bin/linux-x64/dsh-dafeiyu-helper'
+const darwinBundledPath = '/package/runtime/bin/darwin/dsh-dafeiyu-helper.app/Contents/MacOS/dsh-dafeiyu-helper'
 const helperPath = '/package/runtime/helper.py'
 
 function resolve(overrides = {}) {
@@ -12,6 +13,7 @@ function resolve(overrides = {}) {
     isWslEnv: false,
     bundledPath,
     linuxBundledPath,
+    darwinBundledPath,
     helperPath,
     fileExists: () => true,
     windowsPath: () => 'C:\\package\\runtime\\bin\\win32-x64\\dsh-dafeiyu-helper.exe',
@@ -21,6 +23,24 @@ function resolve(overrides = {}) {
 
 test('native Windows launches the bundled x64 helper directly', () => {
   assert.deepEqual(resolve({ platform: 'win32' }), { command: bundledPath, args: [] })
+})
+
+test('native macOS launches the bundled universal helper directly', () => {
+  assert.deepEqual(resolve({ platform: 'darwin' }), {
+    command: darwinBundledPath,
+    args: [],
+  })
+})
+
+test('macOS falls back to configured Python when its bundle is absent', () => {
+  assert.deepEqual(resolve({
+    platform: 'darwin',
+    fileExists: () => false,
+    pythonEnv: '/opt/dsh/python',
+  }), {
+    command: '/opt/dsh/python',
+    args: [helperPath],
+  })
 })
 
 test('WSL visual mode uses an absolute cmd.exe path, not the bare name on PATH', () => {


### PR DESCRIPTION
## Summary

- integrate #26's native Swift/AppKit Helper on current main as a macOS 12+ universal arm64/x86_64 app
- launch the bundled app directly on Darwin while preserving Windows, WSL, and Linux selection
- align the native runtime with current settings and protocol behavior: 55% mini scale, settings persistence reports, bubble visibility, notification-sound setting, Unix timestamps, and stdin-EOF shutdown
- build, ad-hoc sign, verify both architectures, render a real AppKit snapshot, and test shutdown/EOF lifecycle on macOS pull-request CI
- add macOS as a third native artifact in trusted publishing, then re-check the exact final npm archive on a macOS runner before npm OIDC publishing
- document that ad-hoc signing validates integrity but is not Developer ID signing/notarization

This supersedes #26 while preserving its commits and authorship. It advances #24, but deliberately does not close it: Apple Developer ID signing/notarization and owner hardware acceptance remain separate release gates.

## Local verification

- `npm test` — 62 passed
- `npm run test:python` — 17 passed
- workflow YAML parsed locally
- Swift compilation, universal architecture, codesign structure, AppKit screenshot, and final-archive lifecycle run on GitHub's macOS runner