### PR TITLE
linux桌面支持文档更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@ __pycache__/
 *.py[cod]
 .pytest_cache/
 .dsh-phase0/
-.idea
-venv

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 *.py[cod]
 .pytest_cache/
 .dsh-phase0/
+.idea
+venv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@
   network path.
 - The release script validates `main`, a clean worktree, package version, tag ownership, and remote
   history, then atomically pushes `main` and `v<package version>`. GitHub Actions handles tests,
-  Windows Helper packaging, npm publishing, and the GitHub Release.
+  Windows / Linux x64 / macOS Helper packaging, npm publishing, and the GitHub Release.
 - Use `-DryRun` with either entry point to validate without pushing.
 - npm OIDC trusted publishing cannot run `npm dist-tag`. Promoting a previously published alpha to
   `latest` is a separate package-owner action and must not be faked with a local publish.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Added
 
-- Linux x64 desktop support with a bundled, Python-free Helper, XDG layout persistence, and X11/Wayland platform selection.
+- Linux x64 desktop support with a bundled, Python-free Helper (official binary built on Ubuntu 22.04 / glibc 2.35; desktop verified on Ubuntu 24.04 / glibc 2.39), XDG layout persistence, and X11/Wayland platform selection.
 - Linux Helper build, visual smoke test, and final npm-archive validation in CI and the trusted release workflow.
 - Native macOS Helper built with Swift and AppKit as a universal arm64/x86_64 app for macOS 12+, with no Python runtime requirement.
 - Native macOS build, AppKit screenshot/lifecycle smoke tests, universal-architecture and code-signature checks, plus validation of the final assembled npm archive on a macOS runner.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ stateDiagram-v2
 
 - Windows 10/11 x64，或 WSL2（通过 Windows interop 运行桌面 Helper）
 - Linux x64 桌面（glibc ≥ 2.35；桌面实机仅在 Ubuntu 24.04 / glibc 2.39 验证）
-- macOS 12.0+（Apple Silicon 或 Intel）
+- macOS 12.0+（Apple Silicon 或 Intel，实验性支持）
 - 已安装并能正常运行的 DeepSeek Harness WebUI
 - DSH CLI 中可以使用 `plugin --profile web` 命令
 - npm 上的稳定版 `dsh-dafeiyu`（或抢先测试的 `dsh-dafeiyu@alpha`），或 GitHub Release 中的 `.tgz` 安装包
@@ -168,6 +168,11 @@ pnpm dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
 装完照常启动 DSH WebUI，大肥鱼会由 DSH 自动拉起；不需要手动打开 Helper。
 
 ### macOS 用户（Apple Silicon / Intel，macOS 12.0+）
+
+> `0.1.4` 首次提供实验性的原生 macOS Helper。CI 已验证 Universal 架构、
+> AppKit 渲染和进程生命周期；Apple Silicon 实机体验将继续通过用户反馈验证。
+> 当前应用只有 ad-hoc 签名，尚未 Developer ID 签名或公证，浏览器下载的包可能
+> 被 Gatekeeper 拦截。
 
 macOS 的安装方式与 Windows 相同，只是换成「终端」和 macOS 路径。发布包
 内置原生 Helper，**不需要安装 Python、PySide6 或 Xcode**。

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cd D:\DSH
 然后从 npm 安装稳定版：
 
 ```powershell
-pnpm exec dsh plugin --profile web add dsh-dafeiyu
+pnpm dsh plugin --profile web add dsh-dafeiyu
 ```
 
 如果你的系统已经能直接使用全局 `dsh` 命令，只需要：
@@ -155,20 +155,14 @@ cd ~/deepseek-harness
 然后从 npm 安装稳定版：
 
 ```bash
-pnpm exec dsh plugin --profile web add dsh-dafeiyu
-```
-
-如果系统已经能直接使用全局 `dsh` 命令：
-
-```bash
-dsh plugin --profile web add dsh-dafeiyu
+pnpm dsh plugin --profile web add dsh-dafeiyu
 ```
 
 也可以从 [GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases)
 下载 `dsh-dafeiyu-<version>.tgz`（不要解压），然后安装：
 
 ```bash
-pnpm exec dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
+pnpm dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
 ```
 
 装完照常启动 DSH WebUI，大肥鱼会由 DSH 自动拉起；不需要手动打开 Helper。
@@ -187,7 +181,7 @@ cd ~/deepseek-harness
 然后从 npm 安装稳定版：
 
 ```bash
-pnpm exec dsh plugin --profile web add dsh-dafeiyu
+pnpm dsh plugin --profile web add dsh-dafeiyu
 ```
 
 如果系统已经能直接使用全局 `dsh` 命令：
@@ -200,7 +194,7 @@ dsh plugin --profile web add dsh-dafeiyu
 下载 `dsh-dafeiyu-<version>.tgz`（不要解压），然后安装：
 
 ```bash
-pnpm exec dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
+pnpm dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
 ```
 
 装完照常启动 DSH WebUI，大肥鱼会由 DSH 自动拉起；不要手动打开 Helper。
@@ -218,7 +212,7 @@ dsh-dafeiyu-<version>.tgz
 不解压，在 DSH 目录中直接安装下载的插件包：
 
 ```powershell
-pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<version>.tgz"
+pnpm dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<version>.tgz"
 ```
 
 ### 4. 启动 DSH
@@ -286,13 +280,13 @@ DSH，然后更新 npm 稳定版包：
 
 ```powershell
 cd D:\DSH
-pnpm exec dsh plugin --profile web update dsh-dafeiyu
+pnpm dsh plugin --profile web update dsh-dafeiyu
 ```
 
 也可以再次执行安装命令，它会解析 npm `latest` 标签指向的新版本：
 
 ```powershell
-pnpm exec dsh plugin --profile web add dsh-dafeiyu
+pnpm dsh plugin --profile web add dsh-dafeiyu
 ```
 
 使用 `@alpha` 测试版的用户，把更新命令里的包名换成 `dsh-dafeiyu@alpha` 即可。
@@ -300,7 +294,7 @@ pnpm exec dsh plugin --profile web add dsh-dafeiyu
 使用 GitHub Release 安装的用户，可以下载新 `.tgz` 后覆盖安装：
 
 ```powershell
-pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<new-version>.tgz"
+pnpm dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<new-version>.tgz"
 ```
 
 以上方式都会替换插件及随包携带的 Helper，并保留 DSH 已保存的设置。详细
@@ -312,7 +306,7 @@ pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<new-
 
 ```powershell
 cd D:\DSH
-pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<old-version>.tgz"
+pnpm dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<old-version>.tgz"
 ```
 
 ## 卸载插件
@@ -321,7 +315,7 @@ pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<old-
 
 ```powershell
 cd D:\DSH
-pnpm exec dsh plugin --profile web remove dsh-dafeiyu
+pnpm dsh plugin --profile web remove dsh-dafeiyu
 ```
 
 然后重新启动 DSH。插件代码和 Helper 会从 `web` profile 中移除。DSH 可能保留一份

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ VS Code、浏览器或文件管理器，也能知道 DSH 当前在思考、修�
 
 - 最新版本永远以 [npm `latest`](https://www.npmjs.com/package/dsh-dafeiyu) 和 [GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases) 为准（Releases 里同时提供 `.tgz` 安装包）；顶部的版本徽章会自动更新。
 - 给仓库 **Star 只是收藏，不会收到更新通知**。想第一时间知道「更新了什么」：
-  1. 打开仓库点 **Watch → Custom → Releases**，只订阅 Release 通知；
-  2. 或直接订阅 Releases 的 feed：<https://github.com/QCYTSN/dsh-dafeiyu/releases.atom>
+    1. 打开仓库点 **Watch → Custom → Releases**，只订阅 Release 通知；
+    2. 或直接订阅 Releases 的 feed：<https://github.com/QCYTSN/dsh-dafeiyu/releases.atom>
 - 已安装用户升级：完全退出 DSH 后执行
   ```powershell
   dsh plugin --profile web update dsh-dafeiyu
@@ -85,8 +85,8 @@ stateDiagram-v2
 ## 系统要求
 
 - Windows 10/11 x64，或 WSL2（通过 Windows interop 运行桌面 Helper）
-- Linux x64 桌面环境（原生 X11，或通过 XWayland 运行）
-- macOS 12.0+（Apple Silicon 或 Intel，实验性支持）
+- Linux x64 桌面（glibc ≥ 2.35；桌面实机仅在 Ubuntu 24.04 / glibc 2.39 验证）
+- macOS 12.0+（Apple Silicon 或 Intel）
 - 已安装并能正常运行的 DeepSeek Harness WebUI
 - DSH CLI 中可以使用 `plugin --profile web` 命令
 - npm 上的稳定版 `dsh-dafeiyu`（或抢先测试的 `dsh-dafeiyu@alpha`），或 GitHub Release 中的 `.tgz` 安装包
@@ -102,7 +102,9 @@ x64 和 macOS 的 Helper 都已经包含在发布包里。
 
 先关闭 DSH Host，而不只是关闭浏览器标签页。安装或更新时不要让旧版插件继续运行。
 
-### 2. 一行命令安装
+### 2. 命令安装
+
+### Windows 用户
 
 在 PowerShell 中进入你的 DSH 安装目录，例如：
 
@@ -124,20 +126,54 @@ dsh plugin --profile web add dsh-dafeiyu
 
 想抢先试用新功能（`@alpha` 测试版）的用户，把命令里的包名换成 `dsh-dafeiyu@alpha` 即可。
 
-如果 DSH 运行在 WSL2，请在 WSL 终端执行同一条安装命令。插件会自动通过
-`cmd.exe` 启动包内的 Windows Helper，不需要手动 `chmod`，也不需要在 WSL
-安装 Python 或 PySide6。当前支持范围是 Windows x64 上的 WSL2。
+如果 DSH 运行在 WSL2，请在 WSL 终端执行同一条安装命令。可视模式下插件会
+自动通过 `cmd.exe` 启动包内的 **Windows** Helper，不需要手动 `chmod`，
+也不需要在 WSL 安装 Python 或 PySide6。原生 Linux 桌面请看下一节，使用
+随包的 Linux Helper，而不是 Windows 的 `.exe`。
 
-普通 Linux x64 桌面用户也执行同一条安装命令。`0.1.4` 已内置 Linux Helper，
-无需系统 Python；需要可用的图形桌面会话，原生支持 X11，并可通过 XWayland
-运行。远程无桌面 Linux 和容器不是本版本的显示目标。
+### Linux 用户（x64 桌面，glibc ≥ 2.35）
+
+Linux 桌面的安装方式与 Windows 相同，只是换成终端和 Linux 路径。发布包
+内置预构建 Helper，**不需要安装 Python 或 PySide6**。
+
+系统要求：
+
+- x86_64 桌面发行版，**glibc ≥ 2.35**（官方二进制在 Ubuntu 22.04 上构建）。
+- **桌面实机目前只在 Ubuntu 24.04（glibc 2.39）上验证过。** Ubuntu 22.04 及其他发行版
+  尚未做桌面验收；CI 只在 Ubuntu 22.04 上用 Xvfb 做构建与烟测。
+- 需要图形会话（`DISPLAY` 或 `WAYLAND_DISPLAY`）。Helper 优先走 X11 / XWayland
+  （`xcb`），其次才是 Wayland。
+- Debian / Ubuntu 桌面通常还需要 `libxcb-cursor0`。
+- ARM、无显示器的远程 SSH、容器和纯服务器环境不是本版本的桌面显示目标。
+
+在终端中进入你的 DSH 安装目录（例如 `~/deepseek-harness`）：
+
+```bash
+cd ~/deepseek-harness
+```
+
+然后从 npm 安装稳定版：
+
+```bash
+pnpm exec dsh plugin --profile web add dsh-dafeiyu
+```
+
+如果系统已经能直接使用全局 `dsh` 命令：
+
+```bash
+dsh plugin --profile web add dsh-dafeiyu
+```
+
+也可以从 [GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases)
+下载 `dsh-dafeiyu-<version>.tgz`（不要解压），然后安装：
+
+```bash
+pnpm exec dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
+```
+
+装完照常启动 DSH WebUI，大肥鱼会由 DSH 自动拉起；不需要手动打开 Helper。
 
 ### macOS 用户（Apple Silicon / Intel，macOS 12.0+）
-
-> `0.1.4` 首次提供实验性的原生 macOS Helper。CI 已验证 Universal 架构、
-> AppKit 渲染和进程生命周期；Apple Silicon 实机体验将继续通过用户反馈验证。
-> 当前应用只有 ad-hoc 签名，尚未 Developer ID 签名或公证，浏览器下载的包可能
-> 被 Gatekeeper 拦截。
 
 macOS 的安装方式与 Windows 相同，只是换成「终端」和 macOS 路径。发布包
 内置原生 Helper，**不需要安装 Python、PySide6 或 Xcode**。
@@ -267,7 +303,7 @@ pnpm exec dsh plugin --profile web add dsh-dafeiyu
 pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<new-version>.tgz"
 ```
 
-以上方式都会替换插件及随包携带的 Windows Helper，并保留 DSH 已保存的设置。详细
+以上方式都会替换插件及随包携带的 Helper，并保留 DSH 已保存的设置。详细
 说明见 [插件更新与回退](docs/UPDATING.md)。
 
 ## 回退到旧版本
@@ -299,7 +335,9 @@ pnpm exec dsh plugin --profile web remove dsh-dafeiyu
 1. 确认安装使用的是 `--profile web`。
 2. 完全退出并重新启动 DSH Host。
 3. 进入“设置 → 插件 → 插件配置”确认“启用大肥鱼”已经勾选。
-4. 确认使用 Windows x64 发布包，而不是只克隆了缺少预构建 Helper 的源码。
+4. 确认使用包含对应平台预构建 Helper 的发布包，而不是只克隆了缺少预构建 Helper 的源码。
+   Windows / WSL2 需要 `runtime/bin/win32-x64`；原生 Linux 桌面需要
+   `runtime/bin/linux-x64`；macOS 需要 `runtime/bin/darwin`。
 
 </details>
 
@@ -391,6 +429,17 @@ python -m pip install -r requirements.txt pyinstaller
 $env:DSH_DAFEIYU_BUILD_PYTHON = (Get-Command python).Source
 npm run build:helper:windows
 ```
+
+构建 Linux Helper（需在 Linux x86_64 上；官方发布在 Ubuntu 22.04 上构建，
+以保证 glibc 2.35 基线）：
+
+```bash
+python3 -m pip install -r requirements.txt pyinstaller
+export DSH_DAFEIYU_BUILD_PYTHON="$(command -v python3)"
+npm run build:helper:linux
+```
+
+macOS 原生 Helper 的构建说明见 [native/macos/README.md](native/macos/README.md)。
 
 ## 更多文档
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -87,7 +87,7 @@ When multiple tasks are active, the status bubble lists them at the same time.
 
 - Windows 10/11 x64, or WSL2 (runs the desktop Helper through Windows interop)
 - Linux x64 desktop (glibc ≥ 2.35; desktop verified only on Ubuntu 24.04 / glibc 2.39)
-- macOS 12.0+ (Apple Silicon or Intel)
+- macOS 12.0+ (Apple Silicon or Intel, experimental support)
 - A working DeepSeek Harness WebUI installation
 - A DSH CLI that supports `plugin --profile web`
 - the stable `dsh-dafeiyu` from npm (or `dsh-dafeiyu@alpha` to try prereleases early), or a `.tgz` archive from GitHub Releases
@@ -179,6 +179,12 @@ Then launch DSH WebUI normally; BigFish is started automatically. Do not start
 the Helper yourself.
 
 ### macOS users (Apple Silicon / Intel, macOS 12.0+)
+
+> Version `0.1.4` introduces the native macOS Helper as experimental support.
+> CI verifies its universal architecture, AppKit rendering, and process lifecycle;
+> Apple Silicon experience will continue to be validated through user feedback.
+> The app currently has an ad-hoc signature, not a Developer ID signature or
+> notarization, so Gatekeeper may block browser-downloaded archives.
 
 Installation on macOS is the same as Windows, just in the Terminal with macOS
 paths. The release bundle ships a native Helper — **no Python, PySide6 or Xcode

--- a/README_EN.md
+++ b/README_EN.md
@@ -25,8 +25,8 @@ editing, testing, waiting, or finished while working in VS Code, a browser, or F
 
 - The latest version always matches npm [`latest`](https://www.npmjs.com/package/dsh-dafeiyu) and [GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases) (which also carry the `.tgz` archives); the badges above update automatically.
 - **Starring is just a bookmark — GitHub will not notify you of updates.** To get notified about what changed:
-  1. Open the repo and choose **Watch → Custom → Releases**;
-  2. or subscribe to the Releases feed: <https://github.com/QCYTSN/dsh-dafeiyu/releases.atom>
+    1. Open the repo and choose **Watch → Custom → Releases**;
+    2. or subscribe to the Releases feed: <https://github.com/QCYTSN/dsh-dafeiyu/releases.atom>
 - To upgrade an installed copy: fully exit DSH, then run
   ```powershell
   dsh plugin --profile web update dsh-dafeiyu
@@ -86,8 +86,8 @@ When multiple tasks are active, the status bubble lists them at the same time.
 ## Requirements
 
 - Windows 10/11 x64, or WSL2 (runs the desktop Helper through Windows interop)
-- Linux x64 desktop (native X11, or XWayland)
-- macOS 12.0+ (Apple Silicon or Intel, experimental support)
+- Linux x64 desktop (glibc ≥ 2.35; desktop verified only on Ubuntu 24.04 / glibc 2.39)
+- macOS 12.0+ (Apple Silicon or Intel)
 - A working DeepSeek Harness WebUI installation
 - A DSH CLI that supports `plugin --profile web`
 - the stable `dsh-dafeiyu` from npm (or `dsh-dafeiyu@alpha` to try prereleases early), or a `.tgz` archive from GitHub Releases
@@ -104,7 +104,9 @@ The current Alpha build uses Simplified Chinese for the settings UI and desktop 
 Stop the DSH Host, not only the browser tab. An old Helper should not remain active during
 installation or upgrade.
 
-### 2. Install with one command
+### 2. Install
+
+### Windows users
 
 Open PowerShell in your DSH installation directory, for example:
 
@@ -127,22 +129,62 @@ dsh plugin --profile web add dsh-dafeiyu
 To try new features before they are stable, install from the `@alpha` tag instead:
 `pnpm exec dsh plugin --profile web add dsh-dafeiyu@alpha`.
 
-When DSH runs inside WSL2, run the same install command in the WSL terminal. The plugin
-launches the bundled Windows Helper through `cmd.exe`; no manual `chmod`, Python, or
-PySide6 installation is required inside WSL. The current WSL target is Windows x64.
+When DSH runs inside WSL2, run the same install command in the WSL terminal. In
+visual mode the plugin launches the bundled **Windows** Helper through
+`cmd.exe`; no manual `chmod`, Python, or PySide6 installation is required
+inside WSL. Native Linux desktops use the bundled Linux Helper instead of the
+Windows `.exe` — see the next section.
 
-Regular Linux x64 desktop users run the same install command. Version `0.1.4` bundles
-the Linux Helper with no system Python requirement. A graphical desktop session is
-required; native X11 and XWayland are supported. Headless remote Linux and containers
-are not display targets for this release.
+### Linux users (x64 desktop, glibc ≥ 2.35)
+
+Installation on Linux is the same as Windows, just in a terminal with Linux
+paths. The release bundle ships a prebuilt Helper — **no Python or PySide6
+required**.
+
+Requirements:
+
+- An x86_64 desktop distro with **glibc ≥ 2.35** (the official binary is built
+  on Ubuntu 22.04).
+- **Desktop use has been verified only on Ubuntu 24.04 (glibc 2.39).** Ubuntu
+  22.04 and other distros have not had a real desktop acceptance pass; CI only
+  builds and smoke-tests on Ubuntu 22.04 under Xvfb.
+- A graphical session (`DISPLAY` or `WAYLAND_DISPLAY`). The Helper prefers
+  X11 / XWayland (`xcb`), then Wayland.
+- Debian / Ubuntu desktops usually also need `libxcb-cursor0`.
+- ARM, headless SSH, containers, and server-only environments are not desktop
+  display targets for this version.
+
+In a terminal, `cd` into your DSH installation directory (for example
+`~/deepseek-harness`):
+
+```bash
+cd ~/deepseek-harness
+```
+
+Install the current stable release from npm:
+
+```bash
+pnpm exec dsh plugin --profile web add dsh-dafeiyu
+```
+
+If `dsh` is already available globally:
+
+```bash
+dsh plugin --profile web add dsh-dafeiyu
+```
+
+Alternatively, download `dsh-dafeiyu-<version>.tgz` from
+[GitHub Releases](https://github.com/QCYTSN/dsh-dafeiyu/releases) (do not
+extract it) and install it:
+
+```bash
+pnpm exec dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
+```
+
+Then launch DSH WebUI normally; BigFish is started automatically. Do not start
+the Helper yourself.
 
 ### macOS users (Apple Silicon / Intel, macOS 12.0+)
-
-> Version `0.1.4` introduces the native macOS Helper as experimental support.
-> CI verifies its universal architecture, AppKit rendering, and process lifecycle;
-> Apple Silicon experience will continue to be validated through user feedback.
-> The app currently has an ad-hoc signature, not a Developer ID signature or
-> notarization, so Gatekeeper may block browser-downloaded archives.
 
 Installation on macOS is the same as Windows, just in the Terminal with macOS
 paths. The release bundle ships a native Helper — **no Python, PySide6 or Xcode
@@ -276,7 +318,7 @@ old version:
 pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<new-version>.tgz"
 ```
 
-All three paths replace the plugin and bundled Windows Helper while retaining settings saved
+All three paths replace the plugin and bundled Helper while retaining settings saved
 by DSH. See [Update and rollback](docs/UPDATING.md) for details.
 
 ## Roll back
@@ -308,7 +350,9 @@ an inactive copy of historical settings; it does not start a process or open a p
 1. Confirm that you installed into `--profile web`.
 2. Fully stop and restart the DSH Host.
 3. Open “Settings → Plugins → Plugin configuration” and confirm that BigFish is enabled.
-4. Use the Windows x64 release archive. A source-only clone may not contain the prebuilt Helper.
+4. Use a release archive that contains the prebuilt Helper for your platform, not a
+   source-only clone. Windows / WSL2 needs `runtime/bin/win32-x64`; native Linux
+   desktops need `runtime/bin/linux-x64`; macOS needs `runtime/bin/darwin`.
 
 </details>
 
@@ -406,6 +450,17 @@ python -m pip install -r requirements.txt pyinstaller
 $env:DSH_DAFEIYU_BUILD_PYTHON = (Get-Command python).Source
 npm run build:helper:windows
 ```
+
+Build the Linux Helper (Linux x86_64 required; official releases are built on
+Ubuntu 22.04 to keep the glibc 2.35 baseline):
+
+```bash
+python3 -m pip install -r requirements.txt pyinstaller
+export DSH_DAFEIYU_BUILD_PYTHON="$(command -v python3)"
+npm run build:helper:linux
+```
+
+macOS native Helper build instructions: [native/macos/README.md](native/macos/README.md).
 
 ## More documentation
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -117,7 +117,7 @@ cd D:\DSH
 Install the current stable release from npm:
 
 ```powershell
-pnpm exec dsh plugin --profile web add dsh-dafeiyu
+pnpm dsh plugin --profile web add dsh-dafeiyu
 ```
 
 If `dsh` is already available globally, the command is simply:
@@ -127,7 +127,7 @@ dsh plugin --profile web add dsh-dafeiyu
 ```
 
 To try new features before they are stable, install from the `@alpha` tag instead:
-`pnpm exec dsh plugin --profile web add dsh-dafeiyu@alpha`.
+`pnpm dsh plugin --profile web add dsh-dafeiyu@alpha`.
 
 When DSH runs inside WSL2, run the same install command in the WSL terminal. In
 visual mode the plugin launches the bundled **Windows** Helper through
@@ -164,13 +164,7 @@ cd ~/deepseek-harness
 Install the current stable release from npm:
 
 ```bash
-pnpm exec dsh plugin --profile web add dsh-dafeiyu
-```
-
-If `dsh` is already available globally:
-
-```bash
-dsh plugin --profile web add dsh-dafeiyu
+pnpm dsh plugin --profile web add dsh-dafeiyu
 ```
 
 Alternatively, download `dsh-dafeiyu-<version>.tgz` from
@@ -178,7 +172,7 @@ Alternatively, download `dsh-dafeiyu-<version>.tgz` from
 extract it) and install it:
 
 ```bash
-pnpm exec dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
+pnpm dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
 ```
 
 Then launch DSH WebUI normally; BigFish is started automatically. Do not start
@@ -200,7 +194,7 @@ cd ~/deepseek-harness
 Install the current stable release from npm:
 
 ```bash
-pnpm exec dsh plugin --profile web add dsh-dafeiyu
+pnpm dsh plugin --profile web add dsh-dafeiyu
 ```
 
 If `dsh` is already available globally:
@@ -214,7 +208,7 @@ Alternatively, download `dsh-dafeiyu-<version>.tgz` from
 extract it) and install it:
 
 ```bash
-pnpm exec dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
+pnpm dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
 ```
 
 Then launch DSH WebUI normally; BigFish is started automatically. Do not start
@@ -231,7 +225,7 @@ dsh-dafeiyu-<version>.tgz
 Do not extract it. Install the downloaded archive from the DSH directory:
 
 ```powershell
-pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<version>.tgz"
+pnpm dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<version>.tgz"
 ```
 
 ### 4. Start DSH
@@ -300,13 +294,13 @@ is published, fully exit DSH and update the npm stable package:
 
 ```powershell
 cd D:\DSH
-pnpm exec dsh plugin --profile web update dsh-dafeiyu
+pnpm dsh plugin --profile web update dsh-dafeiyu
 ```
 
 Running the install command again also resolves the newest version behind the npm `latest` tag:
 
 ```powershell
-pnpm exec dsh plugin --profile web add dsh-dafeiyu
+pnpm dsh plugin --profile web add dsh-dafeiyu
 ```
 
 Users who opted into `@alpha` can run the same commands with the package name `dsh-dafeiyu@alpha` instead.
@@ -315,7 +309,7 @@ Users who installed from GitHub Releases can download the new `.tgz` and install
 old version:
 
 ```powershell
-pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<new-version>.tgz"
+pnpm dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<new-version>.tgz"
 ```
 
 All three paths replace the plugin and bundled Helper while retaining settings saved
@@ -327,7 +321,7 @@ Fully exit DSH and install a previously saved release archive with the same `add
 
 ```powershell
 cd D:\DSH
-pnpm exec dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<old-version>.tgz"
+pnpm dsh plugin --profile web add "C:\Users\you\Downloads\dsh-dafeiyu-<old-version>.tgz"
 ```
 
 ## Uninstall
@@ -336,7 +330,7 @@ Fully exit DSH, then run:
 
 ```powershell
 cd D:\DSH
-pnpm exec dsh plugin --profile web remove dsh-dafeiyu
+pnpm dsh plugin --profile web remove dsh-dafeiyu
 ```
 
 Restart DSH afterward. The plugin and Helper are removed from the `web` profile. DSH may keep

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -89,7 +89,7 @@ Do not place a long-lived npm token in WSL merely to perform this promotion.
 
 ## Failure and retry behavior
 
-- A test or Windows build failure stops the release before npm publishing.
+- A test or Helper build failure (Windows, Linux x64, or macOS) stops the release before npm publishing.
 - If npm already contains an identical archive, a retry skips npm and repairs or creates the GitHub
   Release.
 - If npm contains the same version with different archive contents, the workflow stops. Increase the

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,7 +1,7 @@
 # 插件更新与回退
 
 大肥鱼由 DSH 的 `web` profile 管理。Helper 不提供独立更新器，也不要手动替换
-`dsh-dafeiyu-helper.exe`。
+随包二进制（Windows 的 `.exe`、Linux 的 `dsh-dafeiyu-helper` 或 macOS 的 `.app`）。
 
 ## 从 npm Alpha 更新
 
@@ -29,7 +29,7 @@ pnpm exec dsh plugin --profile web add "C:\下载目录\dsh-dafeiyu-<version>.tg
 ```
 
 `add` 会把 `web` profile 中原来的大肥鱼依赖替换为新安装包。重新启动 DSH 后，
-插件、设置卡和随包携带的 Windows Helper 会一起更新。用户设置由 DSH 保存，正常
+插件、设置卡和随包携带的 Helper 会一起更新。用户设置由 DSH 保存，正常
 更新不会要求重新配置。
 
 ## 回退

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -9,13 +9,13 @@
 2. 在 DSH 安装目录运行：
 
 ```powershell
-pnpm exec dsh plugin --profile web update dsh-dafeiyu@alpha
+pnpm dsh plugin --profile web update dsh-dafeiyu@alpha
 ```
 
 也可以重新执行安装命令：
 
 ```powershell
-pnpm exec dsh plugin --profile web add dsh-dafeiyu@alpha
+pnpm dsh plugin --profile web add dsh-dafeiyu@alpha
 ```
 
 ## 从 GitHub Release 安装包更新
@@ -25,7 +25,7 @@ pnpm exec dsh plugin --profile web add dsh-dafeiyu@alpha
 3. 在 DSH 安装目录运行：
 
 ```powershell
-pnpm exec dsh plugin --profile web add "C:\下载目录\dsh-dafeiyu-<version>.tgz"
+pnpm dsh plugin --profile web add "C:\下载目录\dsh-dafeiyu-<version>.tgz"
 ```
 
 `add` 会把 `web` profile 中原来的大肥鱼依赖替换为新安装包。重新启动 DSH 后，
@@ -37,13 +37,13 @@ pnpm exec dsh plugin --profile web add "C:\下载目录\dsh-dafeiyu-<version>.tg
 保留上一个可用版本的 `.tgz`，完全退出 DSH 后，用同一条 `add` 命令重新安装旧包：
 
 ```powershell
-pnpm exec dsh plugin --profile web add "C:\下载目录\dsh-dafeiyu-<old-version>.tgz"
+pnpm dsh plugin --profile web add "C:\下载目录\dsh-dafeiyu-<old-version>.tgz"
 ```
 
 ## 卸载
 
 ```powershell
-pnpm exec dsh plugin --profile web remove dsh-dafeiyu
+pnpm dsh plugin --profile web remove dsh-dafeiyu
 ```
 
 当前 Alpha 包尚未提供自动更新检查，因此 GitHub 仓库出现新提交不会自动改变已经


### PR DESCRIPTION
## 背景

#36 已经把 Linux x64 Helper、CI 构建/烟测和发布合成包合进 `main`，#37 也按同样补了 macOS 文档变更。但 Linux 这边的用户文档似乎被忘记一起带上：README 仍写着“普通 Linux、远程 Linux 和容器不是本版本的桌面显示目标”。

所以此PR仅做出文档上的改动。

## 改动摘要

- 中英文 README 增加 Linux x64 安装说明，写法与现有 macOS 小节对齐。
- 明确当前 npm `latest` 0.1.3 **尚未包含** Linux Helper；普通用户安装命令从下一版本发布后生效。
- 区分两条线：
  - 官方二进制在 Ubuntu 22.04 上构建，兼容性下限是 **glibc ≥ 2.35**。
  - 桌面实机目前只在 **Ubuntu 24.04 / glibc 2.39** 上验证过；其他发行版没有桌面验收，CI 只在 Ubuntu 22.04 上用 Xvfb 做构建和烟测。
- WSL2 可视模式仍通过 `cmd.exe` 启动 **Windows** Helper；原生 Linux 桌面才使用 `runtime/bin/linux-x64`。
- 补充图形会话、`libxcb-cursor0`、不含 ARM / 无头 / 容器等边界，以及 Linux FAQ 和开发构建命令。
- 同步 `CHANGELOG.md`、`docs/UPDATING.md`、`docs/RELEASING.md`。