### PR TITLE
fix: harden linked installs and Helper IPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
           node-version: "24"
           package-manager-cache: false
 
+      - name: Install bundled runtime dependencies
+        run: npm install --ignore-scripts --no-package-lock --omit=dev
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -89,6 +92,7 @@ jobs:
           mkdir -p .build/package-check
           tar -xzf "$archive" -C .build/package-check
           test -x .build/package-check/package/runtime/bin/linux-x64/dsh-dafeiyu-helper
+          node scripts/test-linked-package.mjs .build/package-check/package
           xvfb-run --auto-servernum node scripts/test-packaged-helper.mjs \
             --executable .build/package-check/package/runtime/bin/linux-x64/dsh-dafeiyu-helper
 
@@ -106,11 +110,8 @@ jobs:
           node-version: "24"
           package-manager-cache: false
 
-      - name: Install pnpm
-        run: npm install --global pnpm@11.21.0
-
       - name: Install JavaScript dependencies
-        run: pnpm install --frozen-lockfile
+        run: npm install --ignore-scripts --no-package-lock
 
       - name: Run JavaScript tests
         run: npm test
@@ -141,4 +142,5 @@ jobs:
           test -x "$binary"
           lipo "$binary" -verify_arch arm64 x86_64
           codesign --verify --deep --strict --verbose=2 "$app"
+          node scripts/test-linked-package.mjs .build/package-check/package
           node scripts/test-packaged-helper.mjs --executable "$binary"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,6 +175,9 @@ jobs:
           node-version: "24"
           package-manager-cache: false
 
+      - name: Install bundled runtime dependencies
+        run: npm install --ignore-scripts --no-package-lock --omit=dev
+
       - name: Install Linux display libraries
         run: |
           sudo apt-get update
@@ -214,6 +217,7 @@ jobs:
           test -f .build/package-check/package/runtime/bin/win32-x64/dsh-dafeiyu-helper.exe
           test -x .build/package-check/package/runtime/bin/linux-x64/dsh-dafeiyu-helper
           test -x .build/package-check/package/runtime/bin/darwin/dsh-dafeiyu-helper.app/Contents/MacOS/dsh-dafeiyu-helper
+          node scripts/test-linked-package.mjs .build/package-check/package
           xvfb-run --auto-servernum node scripts/test-packaged-helper.mjs \
             --executable .build/package-check/package/runtime/bin/linux-x64/dsh-dafeiyu-helper
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Bundled the plugin's runtime schema dependencies so DSH profiles can load installs whose package directory is linked from outside the profile tree.
+- Bounded Helper IPC buffering under write backpressure and stopped repeated post-readiness crashes after a finite retry budget, preventing stalled Helpers from causing unbounded memory or process churn.
+
 ## 0.1.4
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -43,8 +43,15 @@
     "node": ">=22.19"
   },
   "dependencies": {
-    "@deepseek-ai/schemastery": "^3.18.1"
+    "@deepseek-ai/cosmokit": "1.8.2",
+    "@deepseek-ai/schemastery": "3.18.1",
+    "@standard-schema/spec": "1.1.0"
   },
+  "bundleDependencies": [
+    "@deepseek-ai/cosmokit",
+    "@deepseek-ai/schemastery",
+    "@standard-schema/spec"
+  ],
   "scripts": {
     "test": "node --test --test-timeout=10000 test/assets.test.js test/config-endpoint.test.js test/client-slot-key.test.js test/helper-command.test.js test/protocol.test.js test/status-copy.test.js test/reducer.test.js test/helper-lifecycle.test.js test/helper-restart.test.js test/plugin-integration.test.js",
     "test:helper": "node --test test/helper-lifecycle.test.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@deepseek-ai/cosmokit':
+        specifier: 1.8.2
+        version: 1.8.2
       '@deepseek-ai/schemastery':
-        specifier: ^3.18.1
+        specifier: 3.18.1
         version: 3.18.1
+      '@standard-schema/spec':
+        specifier: 1.1.0
+        version: 1.1.0
     devDependencies:
       playwright-core:
         specifier: ^1.62.1

--- a/scripts/test-linked-package.mjs
+++ b/scripts/test-linked-package.mjs
@@ -1,0 +1,26 @@
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { isAbsolute, join, resolve } from 'node:path'
+
+const input = process.argv[2]
+if (!input) throw new Error('usage: node scripts/test-linked-package.mjs <extracted-package-directory>')
+
+const packageDirectory = isAbsolute(input) ? input : resolve(process.cwd(), input)
+const directory = await mkdtemp(join(tmpdir(), 'dsh-dafeiyu-linked-package-'))
+const nodeModules = join(directory, 'node_modules')
+const link = join(nodeModules, 'dsh-dafeiyu')
+const entry = join(directory, 'verify.mjs')
+
+try {
+  await mkdir(nodeModules, { recursive: true })
+  await symlink(packageDirectory, link, process.platform === 'win32' ? 'junction' : 'dir')
+  await writeFile(entry, [
+    "import { Config } from 'dsh-dafeiyu'",
+    "if (!Config || !['function', 'object'].includes(typeof Config)) throw new Error('plugin Config did not load')",
+    "process.stdout.write('linked package import passed\\n')",
+  ].join('\n'))
+  execFileSync(process.execPath, [entry], { cwd: directory, stdio: 'inherit' })
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}

--- a/src/helper-process.js
+++ b/src/helper-process.js
@@ -24,6 +24,17 @@ const darwinBundledHelperPath = resolve(
   'MacOS',
   'dsh-dafeiyu-helper',
 )
+const snapshotMessageKinds = new Set([
+  CompanionMessageKind.HELLO,
+  CompanionMessageKind.STATE,
+  CompanionMessageKind.TASK,
+  CompanionMessageKind.TASKS,
+  CompanionMessageKind.CONFIG,
+])
+const coalescibleMessageKinds = new Set([
+  ...snapshotMessageKinds,
+  CompanionMessageKind.PULSE,
+])
 
 function isWsl() {
   if (process.platform !== 'linux') return false
@@ -158,6 +169,9 @@ export class HelperProcess {
     this.heartbeatTimer = undefined
     this.startupTimer = undefined
     this.lastPongAt = 0
+    this.readyAt = 0
+    this.writeBlocked = false
+    this.queueDropWarned = false
   }
 
   start() {
@@ -220,6 +234,8 @@ export class HelperProcess {
       if (this.child !== child) return
       this.child = undefined
       this.spawned = false
+      this.readyAt = 0
+      this.writeBlocked = false
       this.#clearHeartbeat()
       this.#clearStartupTimer()
       if (!this.stopping && !this.restartSuppressed) {
@@ -230,7 +246,10 @@ export class HelperProcess {
       if (this.child !== child) return
       this.child = undefined
       const wasReady = this.spawned
+      const readyAt = this.readyAt
       this.spawned = false
+      this.readyAt = 0
+      this.writeBlocked = false
       this.#clearHeartbeat()
       this.#clearStartupTimer()
       if (!this.stopping && !this.restartSuppressed) {
@@ -241,6 +260,13 @@ export class HelperProcess {
           this.#countStartFailure(`exited before ready (code=${String(code)}, signal=${String(signal)})`)
           return
         }
+        const stableRuntimeMs = this.options.stableRuntimeMs ?? 30000
+        const runtimeMs = readyAt > 0 ? Date.now() - readyAt : 0
+        if (runtimeMs < stableRuntimeMs) {
+          this.#countStartFailure(`exited ${runtimeMs}ms after ready (code=${String(code)}, signal=${String(signal)})`)
+          return
+        }
+        this.startFailures = 0
         this.logger.warn?.(`dsh-dafeiyu helper exited (code=${String(code)}, signal=${String(signal)}); restarting`)
         this.#scheduleRestart()
       }
@@ -257,12 +283,16 @@ export class HelperProcess {
     const line = encodeMessage(message)
     if (!this.child || !this.spawned || !this.child.stdin.writable || this.child.stdin.destroyed) {
       if (!this.hasEverSpawned
-        || ![CompanionMessageKind.HELLO, CompanionMessageKind.STATE, CompanionMessageKind.TASK, CompanionMessageKind.TASKS, CompanionMessageKind.PULSE, CompanionMessageKind.CONFIG].includes(message.kind)) {
-        this.queue.push(line)
+        || !coalescibleMessageKinds.has(message.kind)) {
+        this.#enqueue(message.kind, line)
       }
       return
     }
-    this.child.stdin.write(line)
+    if (this.writeBlocked) {
+      this.#enqueue(message.kind, line)
+      return
+    }
+    this.#writePayload(this.child, line)
   }
 
   stop(reason = 'plugin-disposed') {
@@ -272,7 +302,10 @@ export class HelperProcess {
     this.restartTimer = undefined
     const child = this.child
     if (!child) return
-    this.queue.push(encodeMessage(createMessage(CompanionMessageKind.SHUTDOWN, { reason })))
+    this.#enqueue(
+      CompanionMessageKind.SHUTDOWN,
+      encodeMessage(createMessage(CompanionMessageKind.SHUTDOWN, { reason })),
+    )
     if (this.spawned) {
       this.#flushQueue()
       this.#endInput(child)
@@ -293,16 +326,44 @@ export class HelperProcess {
 
   #flushSnapshot() {
     const child = this.child
-    if (!this.spawned || !child?.stdin.writable || child.stdin.destroyed) return
+    if (this.writeBlocked || !this.spawned || !child?.stdin.writable || child.stdin.destroyed) return
     const payload = [...this.snapshot.values()].join('')
-    if (payload) child.stdin.write(payload)
+    if (payload) this.#writePayload(child, payload)
   }
 
   #flushQueue() {
     const child = this.child
-    if (!this.spawned || !child?.stdin.writable || child.stdin.destroyed) return
-    const payload = this.queue.splice(0).join('')
-    if (payload) child.stdin.write(payload)
+    if (this.writeBlocked || !this.spawned || !child?.stdin.writable || child.stdin.destroyed) return
+    const payload = this.queue.splice(0).map((item) => item.line).join('')
+    if (payload) this.#writePayload(child, payload)
+  }
+
+  #enqueue(kind, line) {
+    if (kind === CompanionMessageKind.PING) return
+    const maxPendingMessages = Math.max(1, this.options.maxPendingMessages ?? 128)
+    if (this.queue.length >= maxPendingMessages) {
+      const sameKind = coalescibleMessageKinds.has(kind)
+        ? this.queue.findIndex((item) => item.kind === kind)
+        : -1
+      this.queue.splice(sameKind >= 0 ? sameKind : 0, 1)
+      if (!this.queueDropWarned) {
+        this.queueDropWarned = true
+        this.logger.warn?.(`dsh-dafeiyu helper message queue reached ${maxPendingMessages}; dropping stale updates`)
+      }
+    }
+    this.queue.push({ kind, line })
+  }
+
+  #writePayload(child, payload) {
+    if (!payload || this.child !== child || !child.stdin.writable || child.stdin.destroyed) return
+    if (child.stdin.write(payload)) return
+    this.writeBlocked = true
+    child.stdin.once('drain', () => {
+      if (this.child !== child || !this.spawned) return
+      this.writeBlocked = false
+      this.queueDropWarned = false
+      this.#flushQueue()
+    })
   }
 
   #handleReply(line) {
@@ -314,7 +375,7 @@ export class HelperProcess {
         const firstSpawn = !this.hasEverSpawned
         this.hasEverSpawned = true
         this.spawned = true
-        this.startFailures = 0
+        this.readyAt = Date.now()
         this.lastPongAt = Date.now()
         this.#clearStartupTimer()
         if (firstSpawn) this.#flushQueue()

--- a/test/fixtures/blocked-input-helper.js
+++ b/test/fixtures/blocked-input-helper.js
@@ -1,0 +1,3 @@
+process.stdout.write(`${JSON.stringify({ protocolVersion: 1, kind: 'ready' })}\n`)
+process.stdin.pause()
+setInterval(() => {}, 1000)

--- a/test/fixtures/crash-after-ready.js
+++ b/test/fixtures/crash-after-ready.js
@@ -1,0 +1,2 @@
+process.stdout.write(`${JSON.stringify({ protocolVersion: 1, kind: 'ready' })}\n`)
+setTimeout(() => process.exit(1), 10)

--- a/test/helper-restart.test.js
+++ b/test/helper-restart.test.js
@@ -10,6 +10,8 @@ import { CompanionMessageKind, CompanionState, createMessage } from '../src/prot
 const fixture = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'restart-helper.js')
 const closedFixture = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'closed-helper.js')
 const crashBeforeReadyFixture = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'crash-before-ready.js')
+const crashAfterReadyFixture = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'crash-after-ready.js')
+const blockedInputFixture = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'blocked-input-helper.js')
 
 async function waitFor(predicate, timeoutMs = 5000) {
   const deadline = Date.now() + timeoutMs
@@ -161,4 +163,58 @@ test('a launch that throws synchronously cannot crash the host and is bounded', 
   assert.equal(bridge.startFailures, afterGiveUp)
   assert.equal(bridge.child, undefined)
   bridge.stop('launch-throw-test-complete')
+})
+
+test('helper that repeatedly crashes just after READY is bounded', async () => {
+  const logger = { debug() {}, info() {}, warn() {}, error() {} }
+  const bridge = new HelperProcess({
+    command: process.execPath,
+    args: [crashAfterReadyFixture],
+    headless: false,
+    heartbeatMs: 0,
+    restartDelayMs: 15,
+    stableRuntimeMs: 1000,
+    maxStartFailures: 3,
+  }, logger)
+  bridge.start()
+
+  await waitFor(() => bridge.restartSuppressed === true)
+  await waitFor(() => bridge.child === undefined)
+  assert.equal(bridge.startFailures, 3)
+  await new Promise((resolve) => setTimeout(resolve, 120))
+  assert.equal(bridge.child, undefined)
+  bridge.stop('crash-after-ready-test-complete')
+})
+
+test('helper input backpressure keeps the pending queue bounded', async () => {
+  const warnings = []
+  const logger = { debug() {}, info() {}, warn(message) { warnings.push(message) }, error() {} }
+  const bridge = new HelperProcess({
+    command: process.execPath,
+    args: [blockedInputFixture],
+    headless: false,
+    heartbeatMs: 0,
+    maxPendingMessages: 8,
+    shutdownTimeoutMs: 50,
+  }, logger)
+  bridge.start()
+  try {
+    await waitFor(() => bridge.spawned === true)
+
+    const detail = 'x'.repeat(64 * 1024)
+    for (let index = 0; index < 200 && !bridge.writeBlocked; index += 1) {
+      bridge.send(createMessage(CompanionMessageKind.PULSE, { state: CompanionState.WORKING, pulse: 'working', detail: `${index}:${detail}` }))
+    }
+    await waitFor(() => bridge.writeBlocked === true)
+    for (let index = 0; index < 32; index += 1) {
+      bridge.send(createMessage(CompanionMessageKind.PULSE, { state: CompanionState.WORKING, pulse: 'working', detail: `${index}:${detail}` }))
+    }
+
+    assert.ok(bridge.queue.length <= 8)
+    assert.ok(warnings.some((message) => String(message).includes('message queue reached 8')))
+    assert.match(JSON.parse(bridge.queue.at(-1).line).detail, /^31:/)
+  } finally {
+    bridge.stop('backpressure-test-complete')
+    await waitFor(() => bridge.child === undefined)
+  }
 })

--- a/test/plugin-integration.test.js
+++ b/test/plugin-integration.test.js
@@ -17,6 +17,11 @@ test('package metadata exposes the DSH web client bundle', () => {
   const metadata = require('dsh-dafeiyu/package.json')
   assert.equal(metadata.exports['./client'], './lib/client.js')
   assert.equal(metadata.dsh.client.platform, 'web')
+  assert.deepEqual(metadata.bundleDependencies, [
+    '@deepseek-ai/cosmokit',
+    '@deepseek-ai/schemastery',
+    '@standard-schema/spec',
+  ])
 })
 
 async function waitFor(predicate, timeoutMs = 5000) {


### PR DESCRIPTION
## Summary

- bundle the exact runtime schema dependency closure into the npm archive, so a plugin package linked from outside the DSH profile can resolve its imports without a manual `pnpm install`
- materialize bundled dependencies with npm in every CI/release job that creates an archive, avoiding pnpm hard links in the published tarball
- verify the extracted package through a simulated external-directory link before CI or trusted publishing can pass
- honor child-stdin backpressure with a bounded 128-message pending queue that drops stale updates instead of growing without limit
- count Helpers that repeatedly exit shortly after `READY` against the existing startup retry budget, preventing an endless respawn loop

The reported event-listener causes are not changed here: subagent events are already rejected at the reducer entry when disabled, state output is signature-deduplicated, and WSL2 visual mode launches the bundled Windows Helper rather than Python. The new safeguards cover the two resource-growth paths that do exist while real-world freeze diagnostics are collected.

## Verification

- `npm test` — 64/64 passed
- `npm run test:python` — 17/17 passed
- workflow YAML parse passed
- clean npm archive contained `schemastery`, `cosmokit`, and `@standard-schema/spec`
- extracted archive imported successfully when linked into a separate simulated DSH profile

Refs #39