### PR TITLE
feat: show active reasoning effort in companion status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Display the reasoning effort that DSH actually applies to each request in the companion status detail, and keep it visible as the task moves between thinking, tool use, and waiting states.
+
 ## 0.1.5
 
 ### Fixed

--- a/src/companion-reducer.js
+++ b/src/companion-reducer.js
@@ -139,9 +139,16 @@ function progressOf(todos) {
   }
 }
 
+function reasoningEffortOf(event) {
+  const value = event?.data?.header?.config?.reasoningEffort
+  if (typeof value !== 'string') return undefined
+  return value.trim().replace(/\s+/gu, ' ').slice(0, 24) || undefined
+}
+
 function detailFor(record, stage = record.payload.stage) {
   const parts = []
   if (record.project) parts.push(record.project)
+  if (record.reasoningEffort) parts.push(`推理 ${record.reasoningEffort}`)
   if (record.progress?.total) parts.push(`已完成 ${record.progress.completed}/${record.progress.total} 步`)
   if (record.task) parts.push(record.task)
   else if (stage) parts.push(stage)
@@ -208,6 +215,14 @@ export class CompanionReducer {
           message: statusCopy('thinking', event.seq),
         })
         return this.#render()
+
+      case 'request/header': {
+        const reasoningEffort = reasoningEffortOf(event)
+        if (reasoningEffort === record.reasoningEffort) return []
+        record.reasoningEffort = reasoningEffort
+        record.updatedAt = ++this.clock
+        return this.#render()
+      }
 
       case 'tool/call': {
         const callId = toolCallIdOf(event, `seq-${String(event.seq ?? 'unknown')}`)
@@ -439,6 +454,7 @@ export class CompanionReducer {
       task: undefined,
       progress: undefined,
       project: undefined,
+      reasoningEffort: undefined,
       subagent: false,
       lastSeq: -1,
       updatedAt: ++this.clock,
@@ -498,6 +514,7 @@ export class CompanionReducer {
         task: selection.record.task,
         progress: selection.record.progress,
         project: selection.record.project,
+        reasoningEffort: selection.record.reasoningEffort,
         detail: detailFor(selection.record),
       }))
     }
@@ -539,6 +556,7 @@ export class CompanionReducer {
         state: record.state,
         project: record.project,
         task: record.task,
+        reasoningEffort: record.reasoningEffort,
         message: record.payload.message,
         detail: detailFor(record),
       }))
@@ -564,6 +582,7 @@ export class CompanionReducer {
       record.task ?? '',
       record.progress?.completed ?? '',
       record.progress?.total ?? '',
+      record.reasoningEffort ?? '',
     ].join('|')
   }
 }

--- a/test/reducer.test.js
+++ b/test/reducer.test.js
@@ -56,6 +56,53 @@ test('assistant chunks keep one stable thinking message within the same phase', 
   }, 4)), [])
 })
 
+test('request headers show the effective reasoning effort across later states', () => {
+  const reducer = new CompanionReducer()
+  reducer.handle(session, event('turn/start', { turn: 1 }, 1))
+
+  const [withEffort] = reducer.handle(session, event('request/header', {
+    header: {
+      config: {
+        provider: 'deepseek',
+        model: 'deepseek-chat',
+        reasoningEffort: 'high',
+      },
+      adapterDefaults: { reasoningEffort: true },
+    },
+    reason: 'initial',
+  }, 2))
+  assert.equal(withEffort.reasoningEffort, 'high')
+  assert.match(withEffort.detail, /推理 high/u)
+
+  const [working] = reducer.handle(session, event('tool/call', {
+    callId: 'reasoning-work',
+    name: 'apply_patch',
+  }, 3))
+  assert.equal(working.reasoningEffort, 'high')
+  assert.match(working.detail, /推理 high/u)
+
+  assert.deepEqual(reducer.handle(session, event('request/header', {
+    header: { config: { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'high' } },
+    reason: 'change',
+  }, 4)), [])
+})
+
+test('request headers clear the reasoning label for models without an effort', () => {
+  const reducer = new CompanionReducer()
+  reducer.handle(session, event('turn/start', { turn: 1 }, 1))
+  reducer.handle(session, event('request/header', {
+    header: { config: { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'max' } },
+    reason: 'initial',
+  }, 2))
+
+  const [withoutEffort] = reducer.handle(session, event('request/header', {
+    header: { config: { provider: 'mock', model: 'no-reasoning' } },
+    reason: 'change',
+  }, 3))
+  assert.equal(withoutEffort.reasoningEffort, undefined)
+  assert.doesNotMatch(withoutEffort.detail, /推理/u)
+})
+
 test('real DSH tool result callId paths clear completed tools', () => {
   const reducer = new CompanionReducer()
   reducer.handle(session, event('turn/start', { turn: 1 }, 1))


### PR DESCRIPTION
## Summary

- consume DSH `request/header` snapshots and retain the effective `header.config.reasoningEffort` per session
- show the active value (for example, `推理 high`) in the existing companion status detail across thinking, tool use, waiting, task, and pulse transitions
- clear the label when the next model/request has no reasoning effort, and deduplicate unchanged headers
- include the value in state and multi-task payloads so renderers can evolve without another reducer change

The value comes from the request header DSH actually dispatches, including adapter-materialized defaults, rather than guessing from the model selector. Older DSH versions that do not emit this event retain the existing display.

## Verification

- `npm test` — 66 passed
- `npm run test:python` — 17 passed
- targeted reducer suite — 20 passed

Closes #41