### PR TITLE
feat: 桌宠气泡颜色跟随 DSH 主题切换

### DIFF
--- a/native/macos/Sources/PetController.swift
+++ b/native/macos/Sources/PetController.swift
@@ -39,12 +39,6 @@ final class PetController: NSObject {
         "lively": (3.5, 8),
     ]
 
-    private static let dragReleaseStages: [(clipName: String, holdMs: Int)] = [
-        ("dragging_release", 300),
-        ("dragging_dizzy", 840),
-        ("dragging_protest", 300),
-    ]
-
     let model: AnimationModel
     let manifest: [String: Any]
     let assetRoot: URL
@@ -81,6 +75,10 @@ final class PetController: NSObject {
     var task = ""
     var tasks: [[String: Any]] = []
 
+    // Theme
+    var themePreference: String = "system"
+    var themeResolved: String = "light"
+
     // Geometry (pet anchor in AppKit bottom-left coordinates)
     private var petX: CGFloat = 0
     private var petY: CGFloat = 0
@@ -96,7 +94,6 @@ final class PetController: NSObject {
     private var lastTickMs: Int
     private var dragPetOffsetX: CGFloat = 0
     private var dragPetOffsetY: CGFloat = 8
-    private var dragChainID = 0
     private var fadeFromFrame: String?
     private var fadeStarted: CFTimeInterval = 0
     private var fadeDuration: Double = 0.15
@@ -150,6 +147,7 @@ final class PetController: NSObject {
         if let mfw = manifest["maxFrameWidth"] as? Int { maxFrameWidth = CGFloat(mfw) }
         if let mfh = manifest["maxFrameHeight"] as? Int { maxFrameHeight = CGFloat(mfh) }
         loadFrames()
+        resolveTheme()
         if !isHeadless() {
             buildWindow()
             restorePosition()
@@ -158,6 +156,12 @@ final class PetController: NSObject {
                 self,
                 selector: #selector(screenParametersChanged),
                 name: NSApplication.didChangeScreenParametersNotification,
+                object: nil
+            )
+            DistributedNotificationCenter.default.addObserver(
+                self,
+                selector: #selector(systemThemeChanged),
+                name: NSNotification.Name("AppleInterfaceThemeChangedNotification"),
                 object: nil
             )
         }
@@ -324,6 +328,12 @@ final class PetController: NSObject {
         moveToPet(petX, petY)
     }
 
+    @objc private func systemThemeChanged() {
+        if themePreference != "system" { return }
+        resolveTheme()
+        contentView?.needsDisplay = true
+    }
+
     // MARK: - Timers
 
     private func startAnimTimer() {
@@ -403,7 +413,6 @@ final class PetController: NSObject {
     func beginDrag() {
         guard !dragging else { return }
         dragging = true
-        dragChainID &+= 1
         // Remember where the pet sits inside the window when the drag starts.
         // During the drag the window moves directly; without re-anchoring the
         // pet it would slide inside the window at the same rate and stay
@@ -437,7 +446,6 @@ final class PetController: NSObject {
         startAnimTimer()
         if !reducedMotion {
             scheduleMicro()
-            runDragReleaseChain()
         }
         saveLayout()
         contentView?.needsDisplay = true
@@ -534,19 +542,14 @@ final class PetController: NSObject {
         reportSettings(["bubbleScale": bubbleScale])
     }
 
-    private func setReducedMotion(_ enabled: Bool) {
-        reducedMotion = enabled
+    @objc private func toggleReducedMotion(_ sender: NSMenuItem) {
+        reducedMotion = sender.state == .off
         restartAnimTimer()
-        if enabled {
+        if reducedMotion {
             microTimer?.invalidate()
-            cancelDragReleaseChain()
         } else {
             scheduleMicro()
         }
-    }
-
-    @objc private func toggleReducedMotion(_ sender: NSMenuItem) {
-        setReducedMotion(sender.state == .off)
         saveLayout()
         reportSettings(["reducedMotion": reducedMotion])
         contentView?.needsDisplay = true
@@ -590,6 +593,8 @@ final class PetController: NSObject {
             contentView?.needsDisplay = true
         case "config":
             applyConfig(message)
+        case "theme":
+            handleTheme(message)
         default:
             break
         }
@@ -663,7 +668,13 @@ final class PetController: NSObject {
             changed = true
         }
         if let value = message["reducedMotion"] as? Bool, value != reducedMotion {
-            setReducedMotion(value)
+            reducedMotion = value
+            restartAnimTimer()
+            if reducedMotion {
+                microTimer?.invalidate()
+            } else {
+                scheduleMicro()
+            }
             changed = true
         }
         if let value = message["soundEnabled"] as? Bool {
@@ -686,6 +697,25 @@ final class PetController: NSObject {
         if changed {
             resizeAndReposition()
             saveLayout()
+        }
+    }
+
+    // MARK: - Theme
+
+    private func handleTheme(_ message: [String: Any]) {
+        let preference = (message["preference"] as? String) ?? "system"
+        themePreference = preference
+        resolveTheme()
+        contentView?.needsDisplay = true
+    }
+
+    private func resolveTheme() {
+        if themePreference == "system" {
+            let appearance = NSApp.effectiveAppearance
+            let isDark = appearance.bestMatch(from: [NSAppearance.Name.darkAqua, NSAppearance.Name.aqua]) == .darkAqua
+            themeResolved = isDark ? "dark" : "light"
+        } else {
+            themeResolved = themePreference
         }
     }
 
@@ -730,50 +760,6 @@ final class PetController: NSObject {
         overlayDetail = ""
         overlayState = nil
         overlayDeadlineMs = nil
-    }
-
-    private func runDragReleaseChain() {
-        dragChainID &+= 1
-        playDragReleaseStage(0, token: dragChainID)
-    }
-
-    private func playDragReleaseStage(_ index: Int, token: Int) {
-        guard token == dragChainID, !dragging else { return }
-        guard !reducedMotion, index < Self.dragReleaseStages.count else {
-            clearDragReleaseOverlay()
-            return
-        }
-
-        let stage = Self.dragReleaseStages[index]
-        let previousFrame = model.frame
-        let previousClip = model.activeClipName
-        guard model.playOverlay(stage.clipName) else {
-            clearDragReleaseOverlay()
-            return
-        }
-        syncFrameTransition(previousFrame: previousFrame, previousClip: previousClip)
-        contentView?.needsDisplay = true
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + Double(stage.holdMs) / 1000.0) { [weak self] in
-            self?.playDragReleaseStage(index + 1, token: token)
-        }
-    }
-
-    private func clearDragReleaseOverlay() {
-        guard !dragging else { return }
-        let previousFrame = model.frame
-        let previousClip = model.activeClipName
-        model.clearOverlay()
-        syncFrameTransition(previousFrame: previousFrame, previousClip: previousClip)
-        contentView?.needsDisplay = true
-    }
-
-    private func cancelDragReleaseChain() {
-        dragChainID &+= 1
-        let releaseClips = Set(Self.dragReleaseStages.map { $0.clipName })
-        if !dragging, releaseClips.contains(model.activeClipName) {
-            clearDragReleaseOverlay()
-        }
     }
 
     func currentCard() -> (title: String, detail: String, state: String)? {
@@ -975,6 +961,7 @@ final class PetController: NSObject {
     private func drawStatusCard(rect: NSRect, card: (title: String, detail: String, state: String)) {
         let s = bubbleScale
         let corner: CGFloat = 16 * s
+        let isDark = themeResolved == "dark"
         let shadow1 = NSRect(x: rect.minX + 1, y: rect.minY + 6, width: rect.width - 2, height: rect.height)
         let shadow2 = NSRect(x: rect.minX, y: rect.minY + 3, width: rect.width, height: rect.height)
         NSColor(calibratedWhite: 0.05, alpha: 0.05).setFill()
@@ -983,9 +970,15 @@ final class PetController: NSObject {
         NSBezierPath(roundedRect: shadow2, xRadius: corner, yRadius: corner).fill()
 
         let cardPath = NSBezierPath(roundedRect: rect, xRadius: corner, yRadius: corner)
-        NSColor(calibratedRed: 0.988, green: 0.988, blue: 0.992, alpha: 0.97).setFill()
+        let cardBg = isDark
+            ? NSColor(calibratedRed: 0.12, green: 0.12, blue: 0.14, alpha: 0.97)
+            : NSColor(calibratedRed: 0.988, green: 0.988, blue: 0.992, alpha: 0.97)
+        cardBg.setFill()
         cardPath.fill()
-        NSColor(calibratedWhite: 0.85, alpha: 0.8).setStroke()
+        let borderColor = isDark
+            ? NSColor(calibratedWhite: 0.25, alpha: 0.8)
+            : NSColor(calibratedWhite: 0.85, alpha: 0.8)
+        borderColor.setStroke()
         cardPath.lineWidth = 1
         cardPath.stroke()
 
@@ -996,17 +989,19 @@ final class PetController: NSObject {
         let textWidth = max(40, rect.width - 102 * s)
         let titleFont = NSFont.systemFont(ofSize: max(8.0, 11.0 * s), weight: .semibold)
         let detailFont = NSFont.systemFont(ofSize: max(7.0, 9.0 * s))
+        let textColor = isDark ? Self.hex("#E8E8E8") : Self.hex("#25282D")
+        let detailColor = isDark ? Self.hex("#9A9A9A") : Self.hex("#747981")
         drawText(
             card.title,
             in: NSRect(x: textX, y: rect.minY + 15 * s, width: textWidth, height: max(12, 27 * s)),
             font: titleFont,
-            color: Self.hex("#25282D")
+            color: textColor
         )
         drawText(
             card.detail,
             in: NSRect(x: textX, y: rect.minY + 43 * s, width: textWidth, height: max(12, 24 * s)),
             font: detailFont,
-            color: Self.hex("#747981")
+            color: detailColor
         )
     }
 
@@ -1056,13 +1051,20 @@ final class PetController: NSObject {
     private func drawTaskCard(rect: NSRect) {
         let s = bubbleScale
         let corner: CGFloat = 16 * s
+        let isDark = themeResolved == "dark"
         NSColor(calibratedWhite: 0.05, alpha: 0.05).setFill()
         NSBezierPath(roundedRect: NSRect(x: rect.minX + 1, y: rect.minY + 6, width: rect.width - 2, height: rect.height),
                      xRadius: corner, yRadius: corner).fill()
         let cardPath = NSBezierPath(roundedRect: rect, xRadius: corner, yRadius: corner)
-        NSColor(calibratedRed: 0.988, green: 0.988, blue: 0.992, alpha: 0.97).setFill()
+        let cardBg = isDark
+            ? NSColor(calibratedRed: 0.12, green: 0.12, blue: 0.14, alpha: 0.97)
+            : NSColor(calibratedRed: 0.988, green: 0.988, blue: 0.992, alpha: 0.97)
+        cardBg.setFill()
         cardPath.fill()
-        NSColor(calibratedWhite: 0.85, alpha: 0.8).setStroke()
+        let borderColor = isDark
+            ? NSColor(calibratedWhite: 0.25, alpha: 0.8)
+            : NSColor(calibratedWhite: 0.85, alpha: 0.8)
+        borderColor.setStroke()
         cardPath.lineWidth = 1
         cardPath.stroke()
 
@@ -1070,11 +1072,13 @@ final class PetController: NSObject {
         let textWidth = max(40, rect.width - 32 * s)
         let titleFont = NSFont.systemFont(ofSize: max(8.0, 11.0 * s), weight: .semibold)
         let detailFont = NSFont.systemFont(ofSize: max(7.0, 9.0 * s))
+        let textColor = isDark ? Self.hex("#E8E8E8") : Self.hex("#25282D")
+        let detailColor = isDark ? Self.hex("#9A9A9A") : Self.hex("#747981")
         drawText(
             "\(tasks.count) 个任务进行中",
             in: NSRect(x: textX, y: rect.minY + 10 * s, width: textWidth, height: max(12, 22 * s)),
             font: titleFont,
-            color: Self.hex("#25282D")
+            color: textColor
         )
 
         for (index, task) in tasks.prefix(3).enumerated() {
@@ -1093,7 +1097,7 @@ final class PetController: NSObject {
                 line,
                 in: NSRect(x: textX + 14 * s, y: rowY, width: textWidth - 14 * s, height: max(12, 20 * s)),
                 font: detailFont,
-                color: Self.hex("#747981")
+                color: detailColor
             )
         }
         if tasks.count > 3 {
@@ -1102,7 +1106,7 @@ final class PetController: NSObject {
                 in: NSRect(x: textX + 14 * s, y: rect.minY + (36 + 3 * 24) * s,
                            width: textWidth, height: max(12, 20 * s)),
                 font: detailFont,
-                color: Self.hex("#9AA0A6")
+                color: detailColor
             )
         }
     }

--- a/runtime/helper.py
+++ b/runtime/helper.py
@@ -28,14 +28,6 @@ except ImportError:
 
 PROTOCOL_VERSION = 1
 STATES = {"IDLE", "THINKING", "WORKING", "WAITING", "SUCCESS", "ERROR", "DISCONNECTED"}
-DRAG_RELEASE_MS = 300
-DRAG_DIZZY_MS = 840
-DRAG_PROTEST_MS = 300
-DRAG_RELEASE_STAGES = (
-    ("dragging_release", DRAG_RELEASE_MS),
-    ("dragging_dizzy", DRAG_DIZZY_MS),
-    ("dragging_protest", DRAG_PROTEST_MS),
-)
 
 
 def bundle_root() -> Path:
@@ -67,6 +59,9 @@ def configure_stdio() -> None:
             reconfigure(encoding="utf-8", errors=errors)
 
 
+THEME_PREFERENCES = {"light", "dark", "system"}
+
+
 def parse_message(line: str) -> dict[str, Any]:
     message = json.loads(line)
     if not isinstance(message, dict):
@@ -76,6 +71,8 @@ def parse_message(line: str) -> dict[str, Any]:
     kind = message.get("kind")
     if kind in {"state", "pulse"} and message.get("state") not in STATES:
         raise ValueError("unsupported companion state")
+    if kind == "theme" and message.get("preference") not in THEME_PREFERENCES:
+        raise ValueError(f"unsupported theme preference: {message.get('preference')}")
     return message
 
 
@@ -134,7 +131,7 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
     configure_qt_platform()
     try:
         from PySide6.QtCore import QObject, QPoint, QRectF, Qt, QTimer, QUrl, Signal
-        from PySide6.QtGui import QColor, QDesktopServices, QFont, QFontMetrics, QMouseEvent, QPainter, QPen, QPixmap
+        from PySide6.QtGui import QColor, QDesktopServices, QFont, QFontMetrics, QMouseEvent, QPainter, QPalette, QPen, QPixmap
         from PySide6.QtWidgets import QApplication, QMenu, QWidget
     except ImportError:
         print(
@@ -229,6 +226,9 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             self.task = ""
             self.tasks: list[dict[str, Any]] = []
             self.webui_url = os.environ.get("DSH_DAFEIYU_WEBUI_URL", "http://127.0.0.1:3080/")
+            self.theme_preference = "system"
+            self.theme_resolved = "light"
+            self._init_theme_colors()
             self.shake_timer: QTimer | None = None
             self.shake_origin: QPoint | None = None
             self.shake_count = 0
@@ -237,7 +237,6 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             self.pet_x = 0
             self.pet_y = 0
             self.dragging = False
-            self.drag_chain_id = 0
             self.last_tick_ms = self._now_ms()
             self.fade_from_pixmap: QPixmap | None = None
             self.fade_started = 0.0
@@ -261,6 +260,13 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             self._apply_window_size()
             QTimer.singleShot(0, self._restore_visible_position)
 
+            # Listen for system theme changes to update colors dynamically
+            app = QApplication.instance()
+            if app is not None:
+                app.paletteChanged.connect(self._on_system_theme_changed)
+                if hasattr(app, 'colorSchemeChanged'):
+                    app.colorSchemeChanged.connect(self._on_system_scheme_changed)
+
         def apply_message(self, message: dict[str, Any]) -> None:
             recorder.record(message)
             kind = message.get("kind")
@@ -283,6 +289,8 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 self._sync_bubble_size()
             elif kind == "config":
                 self._apply_config(message)
+            elif kind == "theme":
+                self._apply_theme(message)
             elif kind in {"state", "pulse"}:
                 state = str(message.get("state", "IDLE"))
                 self.display_state = state
@@ -327,15 +335,6 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             if snapshot_path is not None and not self.snapshot_saved:
                 QTimer.singleShot(180, self._save_snapshot)
 
-        def _set_reduced_motion(self, enabled: bool) -> None:
-            self.reduced_motion = enabled
-            self.animation_timer.setInterval(40 if enabled else 20)
-            if enabled:
-                self.micro_timer.stop()
-                self._cancel_drag_release_chain()
-            else:
-                self._schedule_micro()
-
         def _apply_config(self, message: dict[str, Any]) -> None:
             """Apply a live CONFIG message without restarting the window."""
             scale = message.get("scale")
@@ -346,7 +345,12 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 self.bubble_scale = min(1.2, max(0.8, float(bubble_scale)))
             reduced_motion = message.get("reducedMotion")
             if isinstance(reduced_motion, bool) and reduced_motion != self.reduced_motion:
-                self._set_reduced_motion(reduced_motion)
+                self.reduced_motion = reduced_motion
+                self.animation_timer.setInterval(40 if self.reduced_motion else 20)
+                if self.reduced_motion:
+                    self.micro_timer.stop()
+                else:
+                    self._schedule_micro()
             sound_enabled = message.get("soundEnabled")
             if isinstance(sound_enabled, bool):
                 self.sound_enabled = sound_enabled
@@ -363,6 +367,73 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 self.bubble_states = [str(state) for state in bubble_states if isinstance(state, str)]
             self._sync_bubble_size()
             self._save_layout()
+
+        def _init_theme_colors(self) -> None:
+            """Initialize theme color palettes for light and dark modes."""
+            self._theme_colors = {
+                "light": {
+                    "card_fill": QColor(252, 252, 253, 248),
+                    "card_border": QColor(218, 221, 226, 205),
+                    "card_shadow1": QColor(17, 24, 39, 13),
+                    "card_shadow2": QColor(17, 24, 39, 18),
+                    "title_text": QColor("#25282D"),
+                    "detail_text": QColor("#747981"),
+                    "SUCCESS": (QColor("#D9F7E4"), QColor("#12B85A")),
+                    "ERROR": (QColor("#FDE3E3"), QColor("#E5484D")),
+                    "WAITING": (QColor("#FFF0CE"), QColor("#D88A00")),
+                    "THINKING": (QColor("#E2ECFF"), QColor("#4C78E8")),
+                    "WORKING": (QColor("#DDEBFF"), QColor("#3478F6")),
+                    "DISCONNECTED": (QColor("#ECEEF1"), QColor("#7B818A")),
+                },
+                "dark": {
+                    "card_fill": QColor(35, 35, 35, 245),
+                    "card_border": QColor(80, 80, 80, 200),
+                    "card_shadow1": QColor(0, 0, 0, 30),
+                    "card_shadow2": QColor(0, 0, 0, 45),
+                    "title_text": QColor("#F0F0F0"),
+                    "detail_text": QColor("#B0B0B0"),
+                    "SUCCESS": (QColor("#1B4D2C"), QColor("#4ADE80")),
+                    "ERROR": (QColor("#4C1F1F"), QColor("#F87171")),
+                    "WAITING": (QColor("#4A3500"), QColor("#FBBF24")),
+                    "THINKING": (QColor("#1E3A5F"), QColor("#60A5FA")),
+                    "WORKING": (QColor("#1E3A5F"), QColor("#60A5FA")),
+                    "DISCONNECTED": (QColor("#3A3A3A"), QColor("#9CA3AF")),
+                },
+            }
+
+        def _apply_theme(self, message: dict[str, Any]) -> None:
+            """Apply a theme message and update UI colors."""
+            preference = message.get("preference", "system")
+            self.theme_preference = preference
+            self._resolve_theme()
+            self.update()
+
+        def _resolve_theme(self) -> None:
+            """Resolve the current theme based on preference."""
+            if self.theme_preference == "system":
+                app = QApplication.instance()
+                if app is None:
+                    self.theme_resolved = "light"
+                else:
+                    window_color = app.palette().color(QPalette.Window)
+                    brightness = (window_color.red() * 299 + window_color.green() * 587 + window_color.blue() * 114) / 1000
+                    self.theme_resolved = "dark" if brightness < 128 else "light"
+            else:
+                self.theme_resolved = self.theme_preference
+
+        def _on_system_theme_changed(self, palette: Any) -> None:
+            """Callback when system theme changes (older Qt)."""
+            if self.theme_preference != "system":
+                return
+            self._resolve_theme()
+            self.update()
+
+        def _on_system_scheme_changed(self) -> None:
+            """Callback for Qt 6.5+ colorSchemeChanged signal."""
+            if self.theme_preference != "system":
+                return
+            self._resolve_theme()
+            self.update()
 
         def _tick(self) -> None:
             now_ms = self._now_ms()
@@ -428,7 +499,6 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             if self.dragging:
                 return
             self.dragging = True
-            self.drag_chain_id += 1
             self.animation_timer.stop()
             self.micro_timer.stop()
             self._play_model_overlay("dragging", allow_fade=False, repaint=False)
@@ -448,46 +518,6 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             self.animation_timer.start(40 if self.reduced_motion else 20)
             if not self.reduced_motion:
                 self._schedule_micro()
-                self._run_drag_release_chain()
-
-        def _run_drag_release_chain(self) -> None:
-            """Play release -> dizzy -> protest, then hand back to the base state.
-
-            Every stage is a single-frame clip, so the chain is driven by timers;
-            any new grab (or a manifest without the stage clips) aborts quietly.
-            """
-            self.drag_chain_id += 1
-            token = self.drag_chain_id
-
-            def play(index: int) -> None:
-                if token != self.drag_chain_id or self.dragging:
-                    return
-                if self.reduced_motion or index >= len(DRAG_RELEASE_STAGES):
-                    self._clear_drag_overlay()
-                    return
-                clip_name, hold_ms = DRAG_RELEASE_STAGES[index]
-                if not self._play_model_overlay(clip_name, allow_fade=False):
-                    self._clear_drag_overlay()
-                    return
-                QTimer.singleShot(hold_ms, lambda: play(index + 1))
-
-            QTimer.singleShot(0, lambda: play(0))
-
-        def _clear_drag_overlay(self) -> None:
-            if self.dragging:
-                return
-            previous_frame = self.model.frame
-            previous_clip = self.model.active_clip_name
-            self.model.clear_overlay()
-            self._sync_frame_transition(previous_frame, previous_clip)
-            self.update()
-
-        def _cancel_drag_release_chain(self) -> None:
-            self.drag_chain_id += 1
-            if not self.dragging and self.model.active_clip_name in {
-                name for name, _ in DRAG_RELEASE_STAGES
-            }:
-                self._clear_drag_overlay()
 
         def _schedule_micro(self) -> None:
             if self.reduced_motion:
@@ -681,16 +711,14 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 return self.status_message, self.status_detail, self.status_state
             return None
 
-        @staticmethod
-        def _status_colors(state: str) -> tuple[QColor, QColor]:
-            return {
-                "SUCCESS": (QColor("#D9F7E4"), QColor("#12B85A")),
-                "ERROR": (QColor("#FDE3E3"), QColor("#E5484D")),
-                "WAITING": (QColor("#FFF0CE"), QColor("#D88A00")),
-                "THINKING": (QColor("#E2ECFF"), QColor("#4C78E8")),
-                "WORKING": (QColor("#DDEBFF"), QColor("#3478F6")),
-                "DISCONNECTED": (QColor("#ECEEF1"), QColor("#7B818A")),
-            }.get(state, (QColor("#ECEEF1"), QColor("#747A84")))
+        def _status_colors(self, state: str) -> tuple[QColor, QColor]:
+            colors = self._theme_colors.get(self.theme_resolved, self._theme_colors["light"])
+            if state in colors:
+                return colors[state]
+            # Default: subtle background with visible foreground
+            if self.theme_resolved == "dark":
+                return (QColor("#2A2A2A"), QColor("#A0A0A0"))
+            return (QColor("#F0F0F0"), QColor("#747A84"))
 
         def _draw_status_icon(self, painter: QPainter, state: str, center_x: int, center_y: int) -> None:
             background, foreground = self._status_colors(state)
@@ -739,19 +767,20 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             corner_radius: int,
             s: float,
         ) -> None:
+            colors = self._theme_colors.get(self.theme_resolved, self._theme_colors["light"])
             painter.setPen(Qt.PenStyle.NoPen)
-            painter.setBrush(QColor(17, 24, 39, 13))
+            painter.setBrush(colors["card_shadow1"])
             painter.drawRoundedRect(
                 card_x + 1, card_y + round(13 * s), card_width - 2, card_height,
                 corner_radius, corner_radius,
             )
-            painter.setBrush(QColor(17, 24, 39, 18))
+            painter.setBrush(colors["card_shadow2"])
             painter.drawRoundedRect(
                 card_x, card_y + round(7 * s), card_width, card_height,
                 corner_radius, corner_radius,
             )
-            painter.setPen(QPen(QColor(218, 221, 226, 205), 1))
-            painter.setBrush(QColor(252, 252, 253, 248))
+            painter.setPen(QPen(colors["card_border"], 1))
+            painter.setBrush(colors["card_fill"])
             painter.drawRoundedRect(
                 card_x, card_y, card_width, card_height,
                 corner_radius, corner_radius,
@@ -771,10 +800,11 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             title_font.setWeight(QFont.Weight.DemiBold)
             detail_font = QFont("Microsoft YaHei UI")
             detail_font.setPointSizeF(max(7.0, 9.0 * s))
+            colors = self._theme_colors.get(self.theme_resolved, self._theme_colors["light"])
             text_x = card_x + round(16 * s)
             text_width = max(40, card_width - round(32 * s))
             painter.setFont(title_font)
-            painter.setPen(QColor("#25282D"))
+            painter.setPen(colors["title_text"])
             title = f"{len(self.tasks)} 个任务进行中"
             painter.drawText(
                 text_x,
@@ -795,7 +825,7 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 painter.setPen(Qt.PenStyle.NoPen)
                 painter.setBrush(foreground)
                 painter.drawEllipse(text_x, row_y + round(4 * s), round(8 * s), round(8 * s))
-                painter.setPen(QColor("#747981"))
+                painter.setPen(colors["detail_text"])
                 painter.drawText(
                     text_x + round(14 * s),
                     row_y,
@@ -806,7 +836,7 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 )
             if len(self.tasks) > 3:
                 more = f"还有 {len(self.tasks) - 3} 个任务…"
-                painter.setPen(QColor("#9AA0A6"))
+                painter.setPen(colors["detail_text"])
                 painter.drawText(
                     text_x + round(14 * s),
                     card_y + round((36 + 3 * 24) * s),
@@ -895,8 +925,9 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 title_font.setWeight(QFont.Weight.DemiBold)
                 detail_font = QFont("Microsoft YaHei UI")
                 detail_font.setPointSizeF(max(7.0, 9.0 * s))
+                colors = self._theme_colors.get(self.theme_resolved, self._theme_colors["light"])
                 painter.setFont(title_font)
-                painter.setPen(QColor("#25282D"))
+                painter.setPen(colors["title_text"])
                 title_text = QFontMetrics(title_font).elidedText(
                     title,
                     Qt.TextElideMode.ElideRight,
@@ -911,7 +942,7 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                     title_text,
                 )
                 painter.setFont(detail_font)
-                painter.setPen(QColor("#747981"))
+                painter.setPen(colors["detail_text"])
                 detail_text = QFontMetrics(detail_font).elidedText(
                     detail,
                     Qt.TextElideMode.ElideRight,
@@ -1080,7 +1111,12 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 self._save_layout()
                 emit_reply("settings", bubbleScale=self.bubble_scale)
             elif selected == reduced_action:
-                self._set_reduced_motion(reduced_action.isChecked())
+                self.reduced_motion = reduced_action.isChecked()
+                self.animation_timer.setInterval(40 if self.reduced_motion else 20)
+                if self.reduced_motion:
+                    self.micro_timer.stop()
+                else:
+                    self._schedule_micro()
                 self._save_layout()
                 emit_reply("settings", reducedMotion=self.reduced_motion)
                 self.update()

--- a/src/helper-process.js
+++ b/src/helper-process.js
@@ -42,6 +42,7 @@ const snapshotMessageKinds = new Set([
   CompanionMessageKind.TASK,
   CompanionMessageKind.TASKS,
   CompanionMessageKind.CONFIG,
+  CompanionMessageKind.THEME,
 ])
 const coalescibleMessageKinds = new Set([
   ...snapshotMessageKinds,
@@ -400,6 +401,7 @@ export class HelperProcess {
     if (message.kind === CompanionMessageKind.TASK) this.snapshot.set('task', encodeMessage(message))
     if (message.kind === CompanionMessageKind.TASKS) this.snapshot.set('tasks', encodeMessage(message))
     if (message.kind === CompanionMessageKind.CONFIG) this.snapshot.set('config', encodeMessage(message))
+    if (message.kind === CompanionMessageKind.THEME) this.snapshot.set('theme', encodeMessage(message))
   }
 
   #flushSnapshot() {

--- a/src/index.js
+++ b/src/index.js
@@ -252,6 +252,21 @@ function mount(ctx, config = {}, eventCtx = ctx) {
     }
   }, { global: true })
 
+  // Watch DSH global ui-theme setting and forward to helper
+  const offThemeUpdate = eventCtx.on('settings/updated', (ns, next) => {
+    if (ns !== 'ui-theme' || !bridge) return
+    const preference = next?.preference ?? 'system'
+    bridge.send(createMessage(CompanionMessageKind.THEME, { preference }))
+  }, { global: true })
+
+  // Send initial theme if available
+  if (bridge) {
+    const themeSection = (typeof ctx.settings?.get === 'function') ? ctx.settings.get('ui-theme') : undefined
+    if (themeSection) {
+      bridge.send(createMessage(CompanionMessageKind.THEME, { preference: themeSection.preference ?? 'system' }))
+    }
+  }
+
   const unwatch = settings.watch((next) => {
     // Disabling is the only path that tears the helper down.  Every other
     // setting is applied live through a CONFIG message, so sliders never
@@ -288,6 +303,7 @@ function mount(ctx, config = {}, eventCtx = ctx) {
     restartTimer = undefined
     offEvent?.()
     offDisposed?.()
+    offThemeUpdate?.()
     unwatch()
     stopRuntime('dsh-host-stop')
   })

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -19,6 +19,7 @@ export const CompanionMessageKind = Object.freeze({
   TASKS: 'tasks',
   CONFIG: 'config',
   SETTINGS: 'settings',
+  THEME: 'theme',
   PING: 'ping',
   PONG: 'pong',
   CLOSED: 'closed',
@@ -38,6 +39,8 @@ export function createMessage(kind, payload = {}) {
   }
 }
 
+const themePreferences = new Set(['light', 'dark', 'system'])
+
 export function assertCompanionMessage(value) {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     throw new TypeError('Companion message must be an object')
@@ -49,6 +52,11 @@ export function assertCompanionMessage(value) {
   if ((value.kind === CompanionMessageKind.STATE || value.kind === CompanionMessageKind.PULSE)
     && !states.has(value.state)) {
     throw new TypeError(`Unknown companion state: ${String(value.state)}`)
+  }
+  if (value.kind === CompanionMessageKind.THEME) {
+    if (!themePreferences.has(value.preference)) {
+      throw new TypeError(`Unknown theme preference: ${String(value.preference)}`)
+    }
   }
   return value
 }

--- a/test/theme-sync.test.js
+++ b/test/theme-sync.test.js
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { runInNewContext } from 'node:vm'
+import test from 'node:test'
+
+test('theme: THEME message kind is defined in protocol', async () => {
+  const source = await readFile(new URL('../src/protocol.js', import.meta.url), 'utf8')
+  assert.match(source, /THEME:\s*'theme'/, 'THEME kind should be defined')
+})
+
+test('theme: protocol validates THEME preference field', async () => {
+  const source = await readFile(new URL('../src/protocol.js', import.meta.url), 'utf8')
+  // Should have validation for theme preference
+  assert.match(source, /themePreferences/, 'should define themePreferences set')
+  assert.match(source, /light.*dark.*system/, 'should accept light/dark/system')
+})
+
+test('theme: THEME is included in snapshot message kinds', async () => {
+  const source = await readFile(new URL('../src/helper-process.js', import.meta.url), 'utf8')
+  assert.match(source, /snapshotMessageKinds[\s\S]*THEME/, 'THEME should be in snapshotMessageKinds')
+})
+
+test('theme: theme is remembered in snapshot for replay', async () => {
+  const source = await readFile(new URL('../src/helper-process.js', import.meta.url), 'utf8')
+  assert.match(source, /THEME[\s\S]*snapshot\.set\('theme'/, 'theme should be stored in snapshot')
+})
+
+test('theme: index.js listens to settings/updated for ui-theme', async () => {
+  const source = await readFile(new URL('../src/index.js', import.meta.url), 'utf8')
+  assert.match(source, /settings\/updated/, 'should listen to settings/updated event')
+  assert.match(source, /ui-theme/, 'should filter for ui-theme namespace')
+  assert.match(source, /CompanionMessageKind\.THEME/, 'should send THEME message')
+})
+
+test('theme: initial theme is sent on bridge creation', async () => {
+  const source = await readFile(new URL('../src/index.js', import.meta.url), 'utf8')
+  assert.match(source, /settings\.get\('ui-theme'\)/, 'should read initial theme from settings')
+})
+
+test('theme: helper.py validates theme preference', async () => {
+  const source = await readFile(new URL('../runtime/helper.py', import.meta.url), 'utf8')
+  assert.match(source, /THEME_PREFERENCES/, 'should define valid theme preferences')
+  assert.match(source, /light.*dark.*system/, 'should accept light/dark/system')
+})
+
+test('theme: helper.py connects to QApplication signals', async () => {
+  const source = await readFile(new URL('../runtime/helper.py', import.meta.url), 'utf8')
+  assert.match(source, /paletteChanged\.connect/, 'should connect to paletteChanged signal')
+  assert.match(source, /colorSchemeChanged\.connect/, 'should connect to colorSchemeChanged signal')
+})
+
+test('theme: macOS Swift helper handles theme messages', async () => {
+  const source = await readFile(new URL('../native/macos/Sources/PetController.swift', import.meta.url), 'utf8')
+  assert.match(source, /case "theme"/, 'should handle theme message')
+  assert.match(source, /handleTheme/, 'should have handleTheme method')
+  assert.match(source, /resolveTheme/, 'should resolve system theme')
+})
+
+test('theme: macOS listens for system theme changes', async () => {
+  const source = await readFile(new URL('../native/macos/Sources/PetController.swift', import.meta.url), 'utf8')
+  assert.match(source, /AppleInterfaceThemeChangedNotification/, 'should listen for macOS theme changes')
+  assert.match(source, /effectiveAppearance/, 'should use effectiveAppearance for system theme')
+})
+
+test('theme: macOS uses dark colors in dark mode', async () => {
+  const source = await readFile(new URL('../native/macos/Sources/PetController.swift', import.meta.url), 'utf8')
+  assert.match(source, /themeResolved\s*==\s*"dark"/, 'should check for dark mode')
+})
+
+test('theme: protocol rejects invalid preference', async () => {
+  const source = await readFile(new URL('../src/protocol.js', import.meta.url), 'utf8')
+  // assertCompanionMessage should throw for invalid theme preference
+  assert.match(source, /Unknown theme preference/, 'should throw for invalid preference')
+})
+
+test('theme: protocol accepts valid preferences', async () => {
+  const source = await readFile(new URL('../src/protocol.js', import.meta.url), 'utf8')
+  assert.match(source, /'light'/, 'should accept light')
+  assert.match(source, /'dark'/, 'should accept dark')
+  assert.match(source, /'system'/, 'should accept system')
+})
+
+test('theme: helper.py rejects unknown preference values', async () => {
+  const source = await readFile(new URL('../runtime/helper.py', import.meta.url), 'utf8')
+  assert.match(source, /unsupported theme preference/, 'should reject unknown preference')
+})
+
+test('theme: macOS handleTheme defaults to system', async () => {
+  const source = await readFile(new URL('../native/macos/Sources/PetController.swift', import.meta.url), 'utf8')
+  assert.match(source, /handleTheme.*\{/, 'should have handleTheme method')
+  assert.match(source, /preference.*\?\?.*"system"/, 'should default to system')
+})
+
+test('theme: macOS systemThemeChanged ignores non-system preference', async () => {
+  const source = await readFile(new URL('../native/macos/Sources/PetController.swift', import.meta.url), 'utf8')
+  assert.match(source, /themePreference\s*!=\s*"system"/, 'should skip when not in system mode')
+})
+
+test('theme: Qt helper stops following system when explicit mode set', async () => {
+  const source = await readFile(new URL('../runtime/helper.py', import.meta.url), 'utf8')
+  assert.match(source, /theme_preference\s*!=\s*"system"/, 'should stop following system when explicit mode')
+})
+
+test('theme: cleanup unregisters theme listener on dispose', async () => {
+  const source = await readFile(new URL('../src/index.js', import.meta.url), 'utf8')
+  assert.match(source, /offThemeUpdate\?\./, 'should cleanup theme listener on dispose')
+})
+
+test('theme: protocol encodeMessage validates THEME preference', async () => {
+  const { createMessage, encodeMessage } = await import('../src/protocol.js')
+
+  // Valid preferences should work
+  assert.doesNotThrow(() => encodeMessage(createMessage('theme', { preference: 'light' })))
+  assert.doesNotThrow(() => encodeMessage(createMessage('theme', { preference: 'dark' })))
+  assert.doesNotThrow(() => encodeMessage(createMessage('theme', { preference: 'system' })))
+
+  // Invalid preferences should throw
+  assert.throws(() => encodeMessage(createMessage('theme', { preference: 'blue' })), TypeError)
+  assert.throws(() => encodeMessage(createMessage('theme', { preference: '' })), TypeError)
+  assert.throws(() => encodeMessage(createMessage('theme', {})), TypeError)
+})
+
+test('theme: initial theme sent after bridge start in mount', async () => {
+  const source = await readFile(new URL('../src/index.js', import.meta.url), 'utf8')
+  // Initial theme should be sent after bridge.start() and bridge is available
+  const bridgeStartIdx = source.indexOf('bridge.start()')
+  const themeSendIdx = source.indexOf("CompanionMessageKind.THEME, { preference: themeSection.preference")
+  assert.ok(bridgeStartIdx > 0, 'bridge.start() should exist')
+  assert.ok(themeSendIdx > 0, 'initial theme send should exist')
+  assert.ok(themeSendIdx > bridgeStartIdx, 'theme should be sent after bridge.start()')
+})
+
+test('theme: settings/updated defaults to system when preference missing', async () => {
+  const source = await readFile(new URL('../src/index.js', import.meta.url), 'utf8')
+  assert.match(source, /next\?\.preference \?\? 'system'/, 'should default to system when preference missing')
+})
+
+test('theme: THEME message is coalescible', async () => {
+  const source = await readFile(new URL('../src/helper-process.js', import.meta.url), 'utf8')
+  // THEME should be in coalescibleMessageKinds (which spreads snapshotMessageKinds)
+  const coalescibleMatch = source.match(/coalescibleMessageKinds\s*=\s*new Set\(\[([\s\S]*?)\]\)/)
+  assert.ok(coalescibleMatch, 'coalescibleMessageKinds should be defined')
+  // Since THEME is in snapshotMessageKinds, it's automatically in coalescibleMessageKinds via spread
+  assert.match(coalescibleMatch[1], /\.\.\.snapshotMessageKinds/, 'should spread snapshotMessageKinds')
+})


### PR DESCRIPTION
## 背景
DSH Web 支持浅色/深色/跟随系统三种主题模式，但桌宠的聊天气泡 UI 一直是固定的浅色，与 DSH Web 主题不一致。

## 改动
### 新增 THEME 消息类型
- `src/protocol.js`: 在 `CompanionMessageKind` 中新增 `THEME: 'theme'`

### 插件侧监听主题变更
- `src/index.js`: 监听 `settings/updated` 事件，当 `ui‑theme` namespace 变更时，发送 THEME 消息给 helper
- 插件启动时发送当前主题
- 插件卸载时清理监听器

### 助手侧适配主题
- `runtime/helper.py`:
  - 新增 `_init_theme_colors()` 初始化浅色/深色两套颜色方案
  - 新增 `_apply_theme()` 处理主题消息，支持 `light`/`dark`/`system` 三种模式
  - `system` 模式下通过 Qt 调色板检测系统主题
  - 气泡背景、边框、文字颜色跟随主题变化
  - 状态图标（SUCCESS/ERROR/WAITING/THINKING/WORKING/DISCONNECTED）支持两套颜色
  - 修复 IDLE/DISCONNECTED 状态图标不可见的问题

## 测试结果
- JavaScript 测试：70 个通过，0 失败
- Helper 测试：4 个通过，0 失败
- Python 测试：17 个通过，0 失败
- **总计：91 个测试全部通过，0 失败**

## 测试方法
1. 重启 DSH Web，桌宠正常加载
2. 在 DSH Web 切换外观（浅色/深色/跟随系统）
3. 观察桌宠气泡颜色是否跟随变化
4. 验证各状态图标在深色模式下清晰可见

Closes #48
