### PR TITLE
fix: avoid repeated UNC Helper startup cost on WSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Display the reasoning effort that DSH actually applies to each request in the companion status detail, and keep it visible as the task moves between thinking, tool use, and waiting states.
 
+### Fixed
+
+- WSL visual mode now caches the bundled Windows Helper under the Windows user's local app-data directory before launching it. Re-enabling the pet no longer makes Windows repeatedly read and unpack the large PyInstaller executable through `\\wsl.localhost`; cache failures still fall back to the packaged Helper.
+
 ## 0.1.5
 
 ### Fixed

--- a/src/helper-process.js
+++ b/src/helper-process.js
@@ -1,5 +1,14 @@
 import { execFileSync, spawn } from 'node:child_process'
-import { chmodSync, existsSync, readFileSync } from 'node:fs'
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
@@ -24,6 +33,9 @@ const darwinBundledHelperPath = resolve(
   'MacOS',
   'dsh-dafeiyu-helper',
 )
+const packageVersion = JSON.parse(
+  readFileSync(resolve(here, '..', 'package.json'), 'utf8'),
+).version
 const snapshotMessageKinds = new Set([
   CompanionMessageKind.HELLO,
   CompanionMessageKind.STATE,
@@ -92,6 +104,60 @@ function defaultWslPath(...args) {
   return execFileSync('wslpath', args, { encoding: 'utf8' }).trim()
 }
 
+function defaultWindowsLocalAppData({
+  cmdExe = defaultCmdExe,
+  wslpath = defaultWslPath,
+  run = execFileSync,
+} = {}) {
+  const windowsPath = run(
+    cmdExe(),
+    ['/d', '/c', 'echo %LOCALAPPDATA%'],
+    { encoding: 'utf8', windowsHide: true },
+  ).trim()
+  if (!windowsPath || windowsPath.includes('%LOCALAPPDATA%')) {
+    throw new Error('Windows LOCALAPPDATA is unavailable')
+  }
+  return wslpath('-u', windowsPath)
+}
+
+function cacheWslBundledHelper({
+  bundledPath,
+  version = packageVersion,
+  localAppData = defaultWindowsLocalAppData,
+  fileExists = existsSync,
+  makeDirectory = mkdirSync,
+  copyFile = copyFileSync,
+  fileStat = statSync,
+  moveFile = renameSync,
+  removeFile = unlinkSync,
+} = {}) {
+  const sourceSize = fileStat(bundledPath).size
+  const safeVersion = String(version || 'unknown').replaceAll(/[^a-zA-Z0-9._-]/g, '_')
+  const cacheDirectory = resolve(localAppData(), 'dsh-dafeiyu', safeVersion)
+  // Published versions are immutable. Including the source size also keeps
+  // local/repacked builds with the same package version from reusing a stale
+  // executable without hashing the large PyInstaller archive on every start.
+  const cachedPath = resolve(cacheDirectory, `dsh-dafeiyu-helper-${sourceSize}.exe`)
+  if (fileExists(cachedPath) && fileStat(cachedPath).size === sourceSize) return cachedPath
+  makeDirectory(cacheDirectory, { recursive: true })
+  const temporaryPath = `${cachedPath}.${process.pid}.tmp`
+  try {
+    copyFile(bundledPath, temporaryPath)
+    if (fileExists(cachedPath) && fileStat(cachedPath).size === sourceSize) return cachedPath
+    if (fileExists(cachedPath)) removeFile(cachedPath)
+    try {
+      moveFile(temporaryPath, cachedPath)
+    } catch (error) {
+      // Another DSH profile may have populated the same immutable cache while
+      // this process was copying. Its complete file is safe to reuse.
+      if (!fileExists(cachedPath) || fileStat(cachedPath).size !== sourceSize) throw error
+    }
+  } finally {
+    if (fileExists(temporaryPath)) removeFile(temporaryPath)
+  }
+  return cachedPath
+}
+
 function resolveHelperLaunch({
   platform,
   isWslEnv,
@@ -104,6 +170,7 @@ function resolveHelperLaunch({
   fileExists = existsSync,
   windowsPath = toWindowsPath,
   cmdExe = defaultCmdExe,
+  wslHelperCache = cacheWslBundledHelper,
 }) {
   if (platform === 'win32' && fileExists(bundledPath)) {
     return { command: bundledPath, args: [] }
@@ -116,9 +183,20 @@ function resolveHelperLaunch({
     // the EXE directly from WSL can therefore fail with EACCES. cmd.exe opens
     // the Windows path without relying on the Linux executable bit and keeps
     // stdin/stdout attached for the companion protocol.
+    let launchPath = bundledPath
+    try {
+      // Running a PyInstaller one-file EXE directly from \\wsl.localhost makes
+      // Windows read and unpack the archive through the WSL file bridge. That
+      // can saturate the WSL VM whenever the plugin starts or is re-enabled.
+      // Cache one immutable copy on the Windows filesystem and reuse it.
+      launchPath = wslHelperCache({ bundledPath })
+    } catch {
+      // Cache preparation is an optimization. Keep the existing UNC launch as
+      // a compatibility fallback for locked-down or unusual WSL installs.
+    }
     return {
       command: cmdExe(),
-      args: ['/d', '/c', windowsPath(bundledPath)],
+      args: ['/d', '/c', windowsPath(launchPath)],
     }
   }
   if (platform === 'linux' && fileExists(linuxBundledPath)) {
@@ -468,6 +546,8 @@ export {
   defaultCmdExe,
   defaultCommand,
   defaultLaunch,
+  defaultWindowsLocalAppData,
+  cacheWslBundledHelper,
   isBundledHelperCommand,
   isWsl,
   resolveHelperLaunch,

--- a/test/helper-command.test.js
+++ b/test/helper-command.test.js
@@ -1,6 +1,14 @@
 import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import test from 'node:test'
-import { defaultCmdExe, resolveHelperLaunch } from '../src/helper-process.js'
+import {
+  cacheWslBundledHelper,
+  defaultCmdExe,
+  defaultWindowsLocalAppData,
+  resolveHelperLaunch,
+} from '../src/helper-process.js'
 
 const bundledPath = '/package/runtime/bin/win32-x64/dsh-dafeiyu-helper.exe'
 const linuxBundledPath = '/package/runtime/bin/linux-x64/dsh-dafeiyu-helper'
@@ -17,6 +25,7 @@ function resolve(overrides = {}) {
     helperPath,
     fileExists: () => true,
     windowsPath: () => 'C:\\package\\runtime\\bin\\win32-x64\\dsh-dafeiyu-helper.exe',
+    wslHelperCache: ({ bundledPath: source }) => source,
     ...overrides,
   })
 }
@@ -59,6 +68,37 @@ test('WSL visual mode falls back to the bare cmd.exe if the absolute path cannot
   })
 })
 
+test('WSL visual mode launches the Windows-local cached helper instead of the UNC source', () => {
+  let convertedPath
+  const cachedPath = '/mnt/c/Users/test/AppData/Local/dsh-dafeiyu/0.1.5/dsh-dafeiyu-helper.exe'
+  assert.deepEqual(resolve({
+    isWslEnv: true,
+    cmdExe: () => '/mnt/c/Windows/System32/cmd.exe',
+    wslHelperCache: () => cachedPath,
+    windowsPath: (path) => {
+      convertedPath = path
+      return 'C:\\Users\\test\\AppData\\Local\\dsh-dafeiyu\\0.1.5\\dsh-dafeiyu-helper.exe'
+    },
+  }), {
+    command: '/mnt/c/Windows/System32/cmd.exe',
+    args: ['/d', '/c', 'C:\\Users\\test\\AppData\\Local\\dsh-dafeiyu\\0.1.5\\dsh-dafeiyu-helper.exe'],
+  })
+  assert.equal(convertedPath, cachedPath)
+})
+
+test('WSL visual mode falls back to the packaged helper when caching fails', () => {
+  let convertedPath
+  resolve({
+    isWslEnv: true,
+    wslHelperCache: () => { throw new Error('cache unavailable') },
+    windowsPath: (path) => {
+      convertedPath = path
+      return 'C:\\package\\runtime\\bin\\win32-x64\\dsh-dafeiyu-helper.exe'
+    },
+  })
+  assert.equal(convertedPath, bundledPath)
+})
+
 test('defaultCmdExe resolves the absolute Windows cmd.exe via wslpath when it exists', () => {
   const resolved = defaultCmdExe({
     wslpath: () => '/mnt/c/Windows/System32/cmd.exe',
@@ -72,6 +112,55 @@ test('defaultCmdExe falls back to the bare cmd.exe when wslpath cannot resolve i
     wslpath: () => { throw new Error('wslpath missing') },
     fileExists: () => true,
   }), 'cmd.exe')
+})
+
+test('defaultWindowsLocalAppData resolves LOCALAPPDATA back to a WSL mount path', () => {
+  const calls = []
+  const localPath = defaultWindowsLocalAppData({
+    cmdExe: () => 'cmd.exe',
+    run: (command, args) => {
+      assert.equal(command, 'cmd.exe')
+      assert.deepEqual(args, ['/d', '/c', 'echo %LOCALAPPDATA%'])
+      return 'C:\\Users\\peanut\\AppData\\Local\r\n'
+    },
+    wslpath: (...args) => {
+      calls.push(args)
+      return '/mnt/c/Users/test/AppData/Local'
+    },
+  })
+  assert.equal(localPath, '/mnt/c/Users/test/AppData/Local')
+  assert.deepEqual(calls, [['-u', 'C:\\Users\\peanut\\AppData\\Local']])
+})
+
+test('cacheWslBundledHelper copies once into a versioned Windows-local cache', () => {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-dafeiyu-wsl-cache-'))
+  const source = join(root, 'package', 'dsh-dafeiyu-helper.exe')
+  const localAppData = join(root, 'windows-local')
+  mkdirSync(join(root, 'package'), { recursive: true })
+  writeFileSync(source, 'helper-binary')
+
+  let copies = 0
+  const copyFile = (from, to) => {
+    copies += 1
+    writeFileSync(to, readFileSync(from))
+  }
+  const first = cacheWslBundledHelper({
+    bundledPath: source,
+    version: '0.1.5',
+    localAppData: () => localAppData,
+    copyFile,
+  })
+  const second = cacheWslBundledHelper({
+    bundledPath: source,
+    version: '0.1.5',
+    localAppData: () => localAppData,
+    copyFile,
+  })
+
+  assert.equal(first, second)
+  assert.match(first.replaceAll('\\', '/'), /windows-local\/dsh-dafeiyu\/0\.1\.5\/dsh-dafeiyu-helper-13\.exe$/)
+  assert.equal(readFileSync(first, 'utf8'), 'helper-binary')
+  assert.equal(copies, 1)
 })
 
 test('WSL headless mode uses the Linux helper so event-log paths stay on Linux', () => {


### PR DESCRIPTION
## 问题

WSL 可视模式当前通过 `cmd.exe` 从 `\\wsl.localhost` 路径启动约 50 MB 的 PyInstaller 单文件 Helper。用户在 #39 的任务管理器截图中看到 `Windows Subsystem for Linux` 占用约 75% CPU；重新启用插件会再次复现。仓库既有验收记录也曾观察到单文件 Helper 的首次安全扫描超过 30 秒。

## 修改

- 首次在 WSL 启动时，将发布版本与文件大小共同标识的 Helper 缓存到 Windows `%LOCALAPPDATA%/dsh-dafeiyu/<version>/`；
- 后续 DSH 重启、禁用后重启直接复用 Windows 本地副本，避免通过 WSL 文件桥重复读取和解包；
- 缓存采用临时文件后重命名，多个 profile 同时启动不会消费半写入文件；
- 无法解析 Windows 本地目录或复制失败时，保持原来的 UNC 启动路径，不影响受限环境；
- 原生 Windows、Linux、macOS 与 WSL headless 路径不变。

## 验证

- `npm test`：70/70 通过
- `py -3 -m unittest discover -s runtime/tests -t .`：17/17 通过
- 补充 WSL 本地缓存、复用、并发安全路径和失败回退测试
- 在本机 WSL 验证 `cmd.exe` 可读取 `%LOCALAPPDATA%`，并能由 `wslpath -u` 转换为 `/mnt/c/...`

Refs #39。合并后仍需要问题报告者用包含该修复的版本做最终 CPU 实机对照，因此本 PR 不自动关闭 Issue。