### PR TITLE
fix: align macOS drag reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Display the reasoning effort that DSH actually applies to each request in the companion status detail, and keep it visible as the task moves between thinking, tool use, and waiting states.
 - Add four community-contributed dragging poses and a short release, dizzy, and protest reaction sequence, with reduced-motion fallback and interruption when the pet is grabbed again.
+- Bring the native macOS Helper to feature parity for that drag-release reaction sequence, including safe cancellation when reduced motion is enabled or the pet is grabbed again.
 
 ### Fixed
 

--- a/native/macos/README.md
+++ b/native/macos/README.md
@@ -33,7 +33,7 @@ PyObjC 在 macOS 26 上崩溃 → EPIPE 未捕获 → 整个 dsh 服务器退出
 - 动画内核：`runtime/animation_model.py` 的忠实移植（clips、pulse、
   overlay、idle 微动作、crossfade、程序化 motion：breathe/think/work/
   wait/bounce/shake/dizzy/float + 行走摆动）
-- 交互：左键拖拽（带 dragging 动画并持久化位置）、单击摸头/戳/尾巴、
+- 交互：左键拖拽（带抓取、松手、眩晕和抗议动画并持久化位置）、单击摸头/戳/尾巴、
   双击、右键菜单（大小/气泡大小/减少动态/打开 WebUI/辅助功能权限/
   本次隐藏/本次关闭）
 - 全屏置顶：`NSWindow.CollectionBehavior` 的 `canJoinAllSpaces` +

--- a/native/macos/Sources/AnimationModel.swift
+++ b/native/macos/Sources/AnimationModel.swift
@@ -17,7 +17,14 @@ final class AnimationModel {
         "IDLE", "THINKING", "WORKING", "WAITING", "SUCCESS", "ERROR", "DISCONNECTED",
     ]
 
-    private static let nonCrossfadeClips: Set<String> = ["blink", "glance", "dragging"]
+    private static let nonCrossfadeClips: Set<String> = [
+        "blink",
+        "glance",
+        "dragging",
+        "dragging_release",
+        "dragging_dizzy",
+        "dragging_protest",
+    ]
 
     /// Same rules as the Python `crossfade_duration`: expression frames stay
     /// crisp, dragging switches atomically.

--- a/native/macos/Sources/PetController.swift
+++ b/native/macos/Sources/PetController.swift
@@ -39,6 +39,12 @@ final class PetController: NSObject {
         "lively": (3.5, 8),
     ]
 
+    private static let dragReleaseStages: [(clipName: String, holdMs: Int)] = [
+        ("dragging_release", 300),
+        ("dragging_dizzy", 840),
+        ("dragging_protest", 300),
+    ]
+
     let model: AnimationModel
     let manifest: [String: Any]
     let assetRoot: URL
@@ -90,6 +96,7 @@ final class PetController: NSObject {
     private var lastTickMs: Int
     private var dragPetOffsetX: CGFloat = 0
     private var dragPetOffsetY: CGFloat = 8
+    private var dragChainID = 0
     private var fadeFromFrame: String?
     private var fadeStarted: CFTimeInterval = 0
     private var fadeDuration: Double = 0.15
@@ -396,6 +403,7 @@ final class PetController: NSObject {
     func beginDrag() {
         guard !dragging else { return }
         dragging = true
+        dragChainID &+= 1
         // Remember where the pet sits inside the window when the drag starts.
         // During the drag the window moves directly; without re-anchoring the
         // pet it would slide inside the window at the same rate and stay
@@ -429,6 +437,7 @@ final class PetController: NSObject {
         startAnimTimer()
         if !reducedMotion {
             scheduleMicro()
+            runDragReleaseChain()
         }
         saveLayout()
         contentView?.needsDisplay = true
@@ -530,6 +539,7 @@ final class PetController: NSObject {
         restartAnimTimer()
         if reducedMotion {
             microTimer?.invalidate()
+            cancelDragReleaseChain()
         } else {
             scheduleMicro()
         }
@@ -653,6 +663,7 @@ final class PetController: NSObject {
             restartAnimTimer()
             if reducedMotion {
                 microTimer?.invalidate()
+                cancelDragReleaseChain()
             } else {
                 scheduleMicro()
             }
@@ -722,6 +733,50 @@ final class PetController: NSObject {
         overlayDetail = ""
         overlayState = nil
         overlayDeadlineMs = nil
+    }
+
+    private func runDragReleaseChain() {
+        dragChainID &+= 1
+        playDragReleaseStage(0, token: dragChainID)
+    }
+
+    private func playDragReleaseStage(_ index: Int, token: Int) {
+        guard token == dragChainID, !dragging else { return }
+        guard !reducedMotion, index < Self.dragReleaseStages.count else {
+            clearDragReleaseOverlay()
+            return
+        }
+
+        let stage = Self.dragReleaseStages[index]
+        let previousFrame = model.frame
+        let previousClip = model.activeClipName
+        guard model.playOverlay(stage.clipName) else {
+            clearDragReleaseOverlay()
+            return
+        }
+        syncFrameTransition(previousFrame: previousFrame, previousClip: previousClip)
+        contentView?.needsDisplay = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Double(stage.holdMs) / 1000.0) { [weak self] in
+            self?.playDragReleaseStage(index + 1, token: token)
+        }
+    }
+
+    private func clearDragReleaseOverlay() {
+        guard !dragging else { return }
+        let previousFrame = model.frame
+        let previousClip = model.activeClipName
+        model.clearOverlay()
+        syncFrameTransition(previousFrame: previousFrame, previousClip: previousClip)
+        contentView?.needsDisplay = true
+    }
+
+    private func cancelDragReleaseChain() {
+        dragChainID &+= 1
+        let releaseClips = Set(Self.dragReleaseStages.map { $0.clipName })
+        if !dragging, releaseClips.contains(model.activeClipName) {
+            clearDragReleaseOverlay()
+        }
     }
 
     func currentCard() -> (title: String, detail: String, state: String)? {


### PR DESCRIPTION
## Summary

- play the same release, dizzy, and protest sequence in the native macOS Helper after a drag
- switch every drag-stage pose atomically and cancel the sequence when the pet is grabbed again
- clear the sequence immediately when reduced motion is enabled or a stage asset is unavailable
- update the native macOS notes and changelog

## Verification

- 
pm test (71 passed)
- 
pm run test:python (20 passed)
- macOS universal build and packaged smoke test run in CI