### PR TITLE
ci: update artifact actions to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           npm run build:helper:windows
 
       - name: Upload Windows Helper
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-helper
           path: runtime/bin/win32-x64/dsh-dafeiyu-helper.exe
@@ -112,7 +112,7 @@ jobs:
         run: xvfb-run --auto-servernum npm run build:helper:linux
 
       - name: Upload Linux Helper
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-helper
           path: runtime/bin/linux-x64/dsh-dafeiyu-helper
@@ -148,7 +148,7 @@ jobs:
           codesign --verify --deep --strict --verbose=2 "$app"
 
       - name: Upload macOS Helper
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-helper
           path: runtime/bin/darwin
@@ -188,19 +188,19 @@ jobs:
             libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0
 
       - name: Download Windows Helper
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-helper
           path: runtime/bin/win32-x64
 
       - name: Download Linux Helper
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-helper
           path: runtime/bin/linux-x64
 
       - name: Download macOS Helper
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: macos-helper
           path: runtime/bin/darwin
@@ -222,7 +222,7 @@ jobs:
             --executable .build/package-check/package/runtime/bin/linux-x64/dsh-dafeiyu-helper
 
       - name: Upload verified archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-package
           path: dsh-dafeiyu-*.tgz
@@ -247,7 +247,7 @@ jobs:
           package-manager-cache: false
 
       - name: Download verified cross-platform package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: npm-package
           path: dist
@@ -285,7 +285,7 @@ jobs:
           package-manager-cache: false
 
       - name: Download verified cross-platform package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: npm-package
           path: dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Update the artifact upload and download actions used by the release workflow to their Node.js 24 versions, removing GitHub-hosted runner deprecation warnings and enforcing artifact digest mismatches as errors.
+
 ## 0.1.6
 
 ### Added


### PR DESCRIPTION
## Summary

- update ctions/upload-artifact from v4 to v7
- update ctions/download-artifact from v4 to v8
- remove Node.js 20 deprecation warnings from the release workflow
- fail closed when a downloaded artifact digest does not match

## Compatibility review

- all downloads select artifacts by name, so the v5 single-ID path change does not apply
- every job uses a GitHub-hosted runner, satisfying the Node.js 24 runner requirement
- existing action inputs remain supported

## Verification

- publish.yml parses as YAML
- no stale artifact v4 references remain
- 
pm test (71 passed)
- 
pm run test:python (20 passed)