### PR TITLE
fix: 缺失依赖时优雅降级，不再拖垮 DSH 启动 (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Added
 
+- Degrade gracefully when a packaged runtime dependency cannot be resolved
+  (for example an incomplete `link:` install): the loader entry now imports
+  the plugin behind a guard, logs one actionable notice naming the missing
+  package and the reinstall command, and exports an inert plugin so the DSH
+  plugin tree and all other plugins keep booting instead of failing with
+  `ERR_MODULE_NOT_FOUND` (#39).
 - Add repeatable Swift unit tests for the native animation state machine
   (`native/macos/Tests/AnimationModelTests.swift`, 18 cases, run via
   `swift test` in CI), ported from `runtime/tests/test_animation_model.py` so

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@standard-schema/spec"
   ],
   "scripts": {
-    "test": "node --test --test-timeout=10000 test/assets.test.js test/config-endpoint.test.js test/client-slot-key.test.js test/helper-command.test.js test/protocol.test.js test/status-copy.test.js test/reducer.test.js test/helper-lifecycle.test.js test/helper-restart.test.js test/plugin-integration.test.js",
+    "test": "node --test --test-timeout=10000 test/assets.test.js test/config-endpoint.test.js test/client-slot-key.test.js test/entry-guard.test.js test/helper-command.test.js test/protocol.test.js test/status-copy.test.js test/reducer.test.js test/helper-lifecycle.test.js test/helper-restart.test.js test/plugin-integration.test.js",
     "test:helper": "node --test test/helper-lifecycle.test.js",
     "test:python": "node scripts/run-python.mjs -m unittest discover -s runtime/tests -t .",
     "helper:headless": "node scripts/run-python.mjs runtime/helper.py --headless",

--- a/src/index.js
+++ b/src/index.js
@@ -1,309 +1,34 @@
-import { createRequire } from 'node:module'
-import Schema from '@deepseek-ai/schemastery'
-import { CompanionReducer } from './companion-reducer.js'
-import { HelperProcess } from './helper-process.js'
-import {
-  CompanionMessageKind,
-  CompanionState,
-  createMessage,
-} from './protocol.js'
-
-const require = createRequire(import.meta.url)
-const pkg = require('../package.json')
-
-export const name = 'dsh-dafeiyu'
-// The plugin's feature is built on session events, and mounting requires the
-// settings service (used to read live config). Keep the declared inject in
-// sync with those real hard dependencies instead of listing a service that
-// is never consumed directly.
-export const inject = ['sessions', 'settings']
-export const CONFIG_ENDPOINT = '/plugins/dsh-dafeiyu/config'
-export const Config = Schema.object({
-  enabled: Schema.boolean().default(true).description('启用桌面大肥鱼'),
-  scale: Schema.number().min(0.55).max(1.4).step(0.05).default(1).role('slider').description('角色大小'),
-  bubbleScale: Schema.number().min(0.8).max(1.2).step(0.05).default(1).role('slider').description('气泡大小'),
-  activityLevel: Schema.union([
-    Schema.const('quiet').description('安静'),
-    Schema.const('normal').description('标准'),
-    Schema.const('lively').description('活泼'),
-  ]).default('normal').description('空闲微动作频率'),
-  reducedMotion: Schema.boolean().default(false).description('减少走动、循环帧和程序化晃动'),
-  soundEnabled: Schema.boolean().default(true).description('任务完成或出错时播放提示音'),
-  bubbleMode: Schema.union([
-    Schema.const('always').description('常驻显示'),
-    Schema.const('hidden').description('完全隐藏'),
-    Schema.const('custom').description('自定义显示状态'),
-  ]).default('always').description('气泡显示模式'),
-  bubbleStates: Schema.array(Schema.string()).default(['SUCCESS', 'ERROR', 'WAITING']).description('自定义模式下显示气泡的状态'),
-  includeSubagents: Schema.boolean().default(false).description('允许子 Agent 抢占宠物状态'),
-}).description('由 DeepSeek Harness 状态驱动的桌面大肥鱼伴侣')
-
-const defaults = Object.freeze({
-  enabled: true,
-  scale: 1,
-  bubbleScale: 1,
-  activityLevel: 'normal',
-  reducedMotion: false,
-  soundEnabled: true,
-  bubbleMode: 'always',
-  bubbleStates: ['SUCCESS', 'ERROR', 'WAITING'],
-  includeSubagents: false,
-})
-
-function publicConfig(config = {}) {
-  return {
-    enabled: config.enabled ?? defaults.enabled,
-    scale: config.scale ?? defaults.scale,
-    bubbleScale: config.bubbleScale ?? defaults.bubbleScale,
-    activityLevel: config.activityLevel ?? defaults.activityLevel,
-    reducedMotion: config.reducedMotion ?? defaults.reducedMotion,
-    soundEnabled: config.soundEnabled ?? defaults.soundEnabled,
-    bubbleMode: config.bubbleMode ?? defaults.bubbleMode,
-    bubbleStates: Array.isArray(config.bubbleStates) ? config.bubbleStates : defaults.bubbleStates,
-    includeSubagents: config.includeSubagents ?? defaults.includeSubagents,
-  }
+// Package entry imported by the DSH plugin loader (see package.json "main").
+// Every external runtime dependency must stay behind the dynamic import
+// below. A static import would throw ERR_MODULE_NOT_FOUND during module
+// resolution when the installed package directory is incomplete (for example
+// a `link:` install whose node_modules was never populated) and abort the
+// whole DSH plugin tree at boot (issue #39). With this guard the same
+// situation degrades into an inert plugin plus a console notice, so DSH and
+// all other plugins keep starting normally.
+let plugin
+try {
+  plugin = await import('./plugin.js')
+} catch (error) {
+  const detail = error instanceof Error ? error.message : String(error)
+  console.error(
+    '[dsh-dafeiyu] 插件依赖加载失败，大肥鱼本次启动已自动停用（不影响 DSH 其他功能）。\n'
+    + `[dsh-dafeiyu] 原因: ${detail}\n`
+    + '[dsh-dafeiyu] 修复: 完全退出 DSH 后重新安装 `dsh plugin --profile web add dsh-dafeiyu@latest`，或补齐缺失依赖后重启。',
+  )
+  plugin = { name: 'dsh-dafeiyu', inject: [], apply() {} }
 }
 
-function localSettingsScope(value) {
-  return {
-    get: () => value,
-    watch: () => () => {},
-  }
-}
-
-function jsonResponse(res, status, body) {
-  const payload = JSON.stringify(body)
-  res.writeHead(status, {
-    'content-type': 'application/json; charset=utf-8',
-    'cache-control': 'no-store',
-    'content-length': Buffer.byteLength(payload),
-  })
-  res.end(payload)
-}
-
-function isLoopback(address) {
-  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1'
-}
-
-async function readPatch(req) {
-  const chunks = []
-  let bytes = 0
-  for await (const chunk of req) {
-    bytes += chunk.length
-    if (bytes > 8192) throw new Error('request body is too large')
-    chunks.push(chunk)
-  }
-  const value = JSON.parse(Buffer.concat(chunks).toString('utf8'))
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error('patch must be an object')
-  const allowed = new Set(Object.keys(defaults))
-  if (Object.keys(value).some((key) => !allowed.has(key))) throw new Error('patch contains an unknown setting')
-  return value
-}
-
-export function createConfigHandler(settings) {
-  return async (req, res) => {
-    if (!isLoopback(req.socket?.remoteAddress)) {
-      jsonResponse(res, 403, { error: 'local access only' })
-      return
-    }
-    const origin = req.headers?.origin
-    if (origin) {
-      let originHost
-      try { originHost = new URL(origin).host } catch {}
-      if (!originHost || originHost !== req.headers.host) {
-        jsonResponse(res, 403, { error: 'origin mismatch' })
-        return
-      }
-    }
-    if (req.method === 'GET') {
-      jsonResponse(res, 200, settings.get())
-      return
-    }
-    if (req.method !== 'PATCH') {
-      jsonResponse(res, 405, { error: 'method not allowed' })
-      return
-    }
-    try {
-      await settings.update(await readPatch(req))
-      jsonResponse(res, 200, settings.get())
-    } catch (error) {
-      jsonResponse(res, 400, { error: error instanceof Error ? error.message : String(error) })
-    }
-  }
-}
-
-function mount(ctx, config = {}, eventCtx = ctx) {
-  const logger = ctx.logger ?? console
-  const base = publicConfig(config)
-  const settings = ctx.settings?.register?.('dsh-dafeiyu', Config, {
-    base,
-    applies: 'live',
-  }) ?? localSettingsScope(base)
-
-  let bridge
-  let reducer
-  let restartTimer
-
-  const stopRuntime = (reason = 'settings-change') => {
-    bridge?.stop(reason)
-    bridge = undefined
-    reducer = undefined
-  }
-
-  const restartRuntime = (next) => {
-    stopRuntime('settings-change')
-    startRuntime(next)
-  }
-
-  const applyLiveSettings = (next) => {
-    for (const message of reducer.setIncludeSubagents(next.includeSubagents === true)) bridge.send(message)
-    bridge.send(createMessage(CompanionMessageKind.CONFIG, {
-      scale: next.scale ?? defaults.scale,
-      bubbleScale: next.bubbleScale ?? defaults.bubbleScale,
-      activityLevel: next.activityLevel ?? defaults.activityLevel,
-      reducedMotion: next.reducedMotion === true,
-      soundEnabled: next.soundEnabled !== false,
-      bubbleMode: next.bubbleMode ?? defaults.bubbleMode,
-      bubbleStates: Array.isArray(next.bubbleStates) ? next.bubbleStates : defaults.bubbleStates,
-    }))
-  }
-
-  const scheduleRestart = (next) => {
-    if (restartTimer) clearTimeout(restartTimer)
-    restartTimer = setTimeout(() => {
-      restartTimer = undefined
-      restartRuntime(next)
-    }, 400)
-    restartTimer.unref?.()
-  }
-
-  const startRuntime = (resolved) => {
-    if (resolved.enabled === false) {
-      logger.info?.('dsh-dafeiyu is disabled')
-      return
-    }
-    const helperConfig = config.helper ?? {}
-    bridge = new HelperProcess({
-      ...helperConfig,
-      env: {
-        ...helperConfig.env,
-        DSH_DAFEIYU_SCALE: String(resolved.scale ?? defaults.scale),
-        DSH_DAFEIYU_BUBBLE_SCALE: String(resolved.bubbleScale ?? defaults.bubbleScale),
-        DSH_DAFEIYU_ACTIVITY_LEVEL: String(resolved.activityLevel ?? defaults.activityLevel),
-        DSH_DAFEIYU_REDUCED_MOTION: resolved.reducedMotion === true ? '1' : '0',
-        DSH_DAFEIYU_SOUND_ENABLED: resolved.soundEnabled !== false ? '1' : '0',
-        DSH_DAFEIYU_BUBBLE_MODE: String(resolved.bubbleMode ?? defaults.bubbleMode),
-        DSH_DAFEIYU_BUBBLE_STATES: (Array.isArray(resolved.bubbleStates) ? resolved.bubbleStates : defaults.bubbleStates).join(','),
-        DSH_DAFEIYU_WEBUI_URL: String(config.webuiUrl ?? process.env.DSH_DAFEIYU_WEBUI_URL ?? 'http://127.0.0.1:3080/'),
-      },
-      onSettingsChange: (report) => {
-        if (typeof settings.update !== 'function') return
-        const patch = {}
-        if (Number.isFinite(report.scale)) patch.scale = Math.min(1.4, Math.max(0.55, report.scale))
-        if (Number.isFinite(report.bubbleScale)) patch.bubbleScale = Math.min(1.2, Math.max(0.8, report.bubbleScale))
-        if (typeof report.reducedMotion === 'boolean') patch.reducedMotion = report.reducedMotion
-        if (Object.keys(patch).length === 0) return
-        void Promise.resolve(settings.update(patch)).catch((error) => {
-          logger.warn?.(`dsh-dafeiyu failed to persist helper settings: ${error instanceof Error ? error.message : String(error)}`)
-        })
-      },
-    }, logger)
-    reducer = new CompanionReducer({ includeSubagents: resolved.includeSubagents === true })
-    bridge.start()
-    bridge.send(createMessage(CompanionMessageKind.HELLO, {
-      state: CompanionState.IDLE,
-      host: 'deepseek-harness',
-      pluginVersion: pkg.version,
-      message: 'BigFish connected to DSH',
-    }))
-    bridge.send(createMessage(CompanionMessageKind.STATE, {
-      state: CompanionState.IDLE,
-      phase: 'plugin-start',
-      stage: '等待任务',
-      message: '我在这儿等新任务哦',
-      detail: 'DSH · 等待下一次任务',
-    }))
-    logger.info?.('dsh-dafeiyu companion bridge started')
-  }
-
-  startRuntime(settings.get())
-
-  // The companion intentionally observes every DSH session. Loader entries may
-  // live inside a scoped composition, so use the unscoped root bus and dispose
-  // the registrations explicitly with this plugin's lifecycle.
-  // Never let an exception from this optional companion escape into the shared
-  // session bus: a throw here could stop every other subscriber from seeing
-  // the event, which would look exactly like "installing the pet broke other
-  // plugins".
-  const offEvent = eventCtx.on('session/event', (session, event) => {
-    if (!bridge || !reducer) return
-    try {
-      for (const message of reducer.handle(session, event)) bridge.send(message)
-    } catch (error) {
-      logger.error?.('dsh-dafeiyu failed to handle session event', error)
-    }
-  }, { global: true })
-  const offDisposed = eventCtx.on('session/disposed', (session) => {
-    if (!bridge || !reducer) return
-    try {
-      for (const message of reducer.disposeSession(session)) bridge.send(message)
-    } catch (error) {
-      logger.error?.('dsh-dafeiyu failed to dispose session', error)
-    }
-  }, { global: true })
-
-  const unwatch = settings.watch((next) => {
-    // Disabling is the only path that tears the helper down.  Every other
-    // setting is applied live through a CONFIG message, so sliders never
-    // restart the pet.  Starting a previously-disabled runtime is debounced
-    // to avoid spawning repeatedly while settings settle.
-    if (next.enabled === false) {
-      if (restartTimer) {
-        clearTimeout(restartTimer)
-        restartTimer = undefined
-      }
-      stopRuntime('settings-change')
-      return
-    }
-    if (!bridge) {
-      scheduleRestart(next)
-      return
-    }
-    if (restartTimer) {
-      clearTimeout(restartTimer)
-      restartTimer = undefined
-    }
-    applyLiveSettings(next)
-  })
-  if (typeof ctx.inject === 'function') {
-    ctx.inject(['webServer'], (httpCtx) => {
-      httpCtx.effect(
-        () => httpCtx.webServer.register({ kind: 'exact', path: CONFIG_ENDPOINT, handler: createConfigHandler(settings) }),
-        'dsh-dafeiyu: local settings endpoint',
-      )
-    })
-  }
-  ctx.effect(() => () => {
-    if (restartTimer) clearTimeout(restartTimer)
-    restartTimer = undefined
-    offEvent?.()
-    offDisposed?.()
-    unwatch()
-    stopRuntime('dsh-host-stop')
-  })
-}
+export const name = plugin.name
+export const inject = plugin.inject
+export const Config = plugin.Config
+export const CONFIG_ENDPOINT = plugin.CONFIG_ENDPOINT
+export const createConfigHandler = plugin.createConfigHandler
+export const CompanionMessageKind = plugin.CompanionMessageKind
+export const CompanionReducer = plugin.CompanionReducer
+export const CompanionState = plugin.CompanionState
+export const HelperProcess = plugin.HelperProcess
 
 export function apply(ctx, config = {}) {
-  if (typeof ctx.inject === 'function') {
-    ctx.inject(['settings'], (settingsCtx) => mount(settingsCtx, config, ctx))
-    return
-  }
-  mount(ctx, config)
-}
-
-export {
-  CompanionMessageKind,
-  CompanionReducer,
-  CompanionState,
-  HelperProcess,
+  return plugin.apply(ctx, config)
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,0 +1,309 @@
+import { createRequire } from 'node:module'
+import Schema from '@deepseek-ai/schemastery'
+import { CompanionReducer } from './companion-reducer.js'
+import { HelperProcess } from './helper-process.js'
+import {
+  CompanionMessageKind,
+  CompanionState,
+  createMessage,
+} from './protocol.js'
+
+const require = createRequire(import.meta.url)
+const pkg = require('../package.json')
+
+export const name = 'dsh-dafeiyu'
+// The plugin's feature is built on session events, and mounting requires the
+// settings service (used to read live config). Keep the declared inject in
+// sync with those real hard dependencies instead of listing a service that
+// is never consumed directly.
+export const inject = ['sessions', 'settings']
+export const CONFIG_ENDPOINT = '/plugins/dsh-dafeiyu/config'
+export const Config = Schema.object({
+  enabled: Schema.boolean().default(true).description('启用桌面大肥鱼'),
+  scale: Schema.number().min(0.55).max(1.4).step(0.05).default(1).role('slider').description('角色大小'),
+  bubbleScale: Schema.number().min(0.8).max(1.2).step(0.05).default(1).role('slider').description('气泡大小'),
+  activityLevel: Schema.union([
+    Schema.const('quiet').description('安静'),
+    Schema.const('normal').description('标准'),
+    Schema.const('lively').description('活泼'),
+  ]).default('normal').description('空闲微动作频率'),
+  reducedMotion: Schema.boolean().default(false).description('减少走动、循环帧和程序化晃动'),
+  soundEnabled: Schema.boolean().default(true).description('任务完成或出错时播放提示音'),
+  bubbleMode: Schema.union([
+    Schema.const('always').description('常驻显示'),
+    Schema.const('hidden').description('完全隐藏'),
+    Schema.const('custom').description('自定义显示状态'),
+  ]).default('always').description('气泡显示模式'),
+  bubbleStates: Schema.array(Schema.string()).default(['SUCCESS', 'ERROR', 'WAITING']).description('自定义模式下显示气泡的状态'),
+  includeSubagents: Schema.boolean().default(false).description('允许子 Agent 抢占宠物状态'),
+}).description('由 DeepSeek Harness 状态驱动的桌面大肥鱼伴侣')
+
+const defaults = Object.freeze({
+  enabled: true,
+  scale: 1,
+  bubbleScale: 1,
+  activityLevel: 'normal',
+  reducedMotion: false,
+  soundEnabled: true,
+  bubbleMode: 'always',
+  bubbleStates: ['SUCCESS', 'ERROR', 'WAITING'],
+  includeSubagents: false,
+})
+
+function publicConfig(config = {}) {
+  return {
+    enabled: config.enabled ?? defaults.enabled,
+    scale: config.scale ?? defaults.scale,
+    bubbleScale: config.bubbleScale ?? defaults.bubbleScale,
+    activityLevel: config.activityLevel ?? defaults.activityLevel,
+    reducedMotion: config.reducedMotion ?? defaults.reducedMotion,
+    soundEnabled: config.soundEnabled ?? defaults.soundEnabled,
+    bubbleMode: config.bubbleMode ?? defaults.bubbleMode,
+    bubbleStates: Array.isArray(config.bubbleStates) ? config.bubbleStates : defaults.bubbleStates,
+    includeSubagents: config.includeSubagents ?? defaults.includeSubagents,
+  }
+}
+
+function localSettingsScope(value) {
+  return {
+    get: () => value,
+    watch: () => () => {},
+  }
+}
+
+function jsonResponse(res, status, body) {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+    'content-length': Buffer.byteLength(payload),
+  })
+  res.end(payload)
+}
+
+function isLoopback(address) {
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1'
+}
+
+async function readPatch(req) {
+  const chunks = []
+  let bytes = 0
+  for await (const chunk of req) {
+    bytes += chunk.length
+    if (bytes > 8192) throw new Error('request body is too large')
+    chunks.push(chunk)
+  }
+  const value = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error('patch must be an object')
+  const allowed = new Set(Object.keys(defaults))
+  if (Object.keys(value).some((key) => !allowed.has(key))) throw new Error('patch contains an unknown setting')
+  return value
+}
+
+export function createConfigHandler(settings) {
+  return async (req, res) => {
+    if (!isLoopback(req.socket?.remoteAddress)) {
+      jsonResponse(res, 403, { error: 'local access only' })
+      return
+    }
+    const origin = req.headers?.origin
+    if (origin) {
+      let originHost
+      try { originHost = new URL(origin).host } catch {}
+      if (!originHost || originHost !== req.headers.host) {
+        jsonResponse(res, 403, { error: 'origin mismatch' })
+        return
+      }
+    }
+    if (req.method === 'GET') {
+      jsonResponse(res, 200, settings.get())
+      return
+    }
+    if (req.method !== 'PATCH') {
+      jsonResponse(res, 405, { error: 'method not allowed' })
+      return
+    }
+    try {
+      await settings.update(await readPatch(req))
+      jsonResponse(res, 200, settings.get())
+    } catch (error) {
+      jsonResponse(res, 400, { error: error instanceof Error ? error.message : String(error) })
+    }
+  }
+}
+
+function mount(ctx, config = {}, eventCtx = ctx) {
+  const logger = ctx.logger ?? console
+  const base = publicConfig(config)
+  const settings = ctx.settings?.register?.('dsh-dafeiyu', Config, {
+    base,
+    applies: 'live',
+  }) ?? localSettingsScope(base)
+
+  let bridge
+  let reducer
+  let restartTimer
+
+  const stopRuntime = (reason = 'settings-change') => {
+    bridge?.stop(reason)
+    bridge = undefined
+    reducer = undefined
+  }
+
+  const restartRuntime = (next) => {
+    stopRuntime('settings-change')
+    startRuntime(next)
+  }
+
+  const applyLiveSettings = (next) => {
+    for (const message of reducer.setIncludeSubagents(next.includeSubagents === true)) bridge.send(message)
+    bridge.send(createMessage(CompanionMessageKind.CONFIG, {
+      scale: next.scale ?? defaults.scale,
+      bubbleScale: next.bubbleScale ?? defaults.bubbleScale,
+      activityLevel: next.activityLevel ?? defaults.activityLevel,
+      reducedMotion: next.reducedMotion === true,
+      soundEnabled: next.soundEnabled !== false,
+      bubbleMode: next.bubbleMode ?? defaults.bubbleMode,
+      bubbleStates: Array.isArray(next.bubbleStates) ? next.bubbleStates : defaults.bubbleStates,
+    }))
+  }
+
+  const scheduleRestart = (next) => {
+    if (restartTimer) clearTimeout(restartTimer)
+    restartTimer = setTimeout(() => {
+      restartTimer = undefined
+      restartRuntime(next)
+    }, 400)
+    restartTimer.unref?.()
+  }
+
+  const startRuntime = (resolved) => {
+    if (resolved.enabled === false) {
+      logger.info?.('dsh-dafeiyu is disabled')
+      return
+    }
+    const helperConfig = config.helper ?? {}
+    bridge = new HelperProcess({
+      ...helperConfig,
+      env: {
+        ...helperConfig.env,
+        DSH_DAFEIYU_SCALE: String(resolved.scale ?? defaults.scale),
+        DSH_DAFEIYU_BUBBLE_SCALE: String(resolved.bubbleScale ?? defaults.bubbleScale),
+        DSH_DAFEIYU_ACTIVITY_LEVEL: String(resolved.activityLevel ?? defaults.activityLevel),
+        DSH_DAFEIYU_REDUCED_MOTION: resolved.reducedMotion === true ? '1' : '0',
+        DSH_DAFEIYU_SOUND_ENABLED: resolved.soundEnabled !== false ? '1' : '0',
+        DSH_DAFEIYU_BUBBLE_MODE: String(resolved.bubbleMode ?? defaults.bubbleMode),
+        DSH_DAFEIYU_BUBBLE_STATES: (Array.isArray(resolved.bubbleStates) ? resolved.bubbleStates : defaults.bubbleStates).join(','),
+        DSH_DAFEIYU_WEBUI_URL: String(config.webuiUrl ?? process.env.DSH_DAFEIYU_WEBUI_URL ?? 'http://127.0.0.1:3080/'),
+      },
+      onSettingsChange: (report) => {
+        if (typeof settings.update !== 'function') return
+        const patch = {}
+        if (Number.isFinite(report.scale)) patch.scale = Math.min(1.4, Math.max(0.55, report.scale))
+        if (Number.isFinite(report.bubbleScale)) patch.bubbleScale = Math.min(1.2, Math.max(0.8, report.bubbleScale))
+        if (typeof report.reducedMotion === 'boolean') patch.reducedMotion = report.reducedMotion
+        if (Object.keys(patch).length === 0) return
+        void Promise.resolve(settings.update(patch)).catch((error) => {
+          logger.warn?.(`dsh-dafeiyu failed to persist helper settings: ${error instanceof Error ? error.message : String(error)}`)
+        })
+      },
+    }, logger)
+    reducer = new CompanionReducer({ includeSubagents: resolved.includeSubagents === true })
+    bridge.start()
+    bridge.send(createMessage(CompanionMessageKind.HELLO, {
+      state: CompanionState.IDLE,
+      host: 'deepseek-harness',
+      pluginVersion: pkg.version,
+      message: 'BigFish connected to DSH',
+    }))
+    bridge.send(createMessage(CompanionMessageKind.STATE, {
+      state: CompanionState.IDLE,
+      phase: 'plugin-start',
+      stage: '等待任务',
+      message: '我在这儿等新任务哦',
+      detail: 'DSH · 等待下一次任务',
+    }))
+    logger.info?.('dsh-dafeiyu companion bridge started')
+  }
+
+  startRuntime(settings.get())
+
+  // The companion intentionally observes every DSH session. Loader entries may
+  // live inside a scoped composition, so use the unscoped root bus and dispose
+  // the registrations explicitly with this plugin's lifecycle.
+  // Never let an exception from this optional companion escape into the shared
+  // session bus: a throw here could stop every other subscriber from seeing
+  // the event, which would look exactly like "installing the pet broke other
+  // plugins".
+  const offEvent = eventCtx.on('session/event', (session, event) => {
+    if (!bridge || !reducer) return
+    try {
+      for (const message of reducer.handle(session, event)) bridge.send(message)
+    } catch (error) {
+      logger.error?.('dsh-dafeiyu failed to handle session event', error)
+    }
+  }, { global: true })
+  const offDisposed = eventCtx.on('session/disposed', (session) => {
+    if (!bridge || !reducer) return
+    try {
+      for (const message of reducer.disposeSession(session)) bridge.send(message)
+    } catch (error) {
+      logger.error?.('dsh-dafeiyu failed to dispose session', error)
+    }
+  }, { global: true })
+
+  const unwatch = settings.watch((next) => {
+    // Disabling is the only path that tears the helper down.  Every other
+    // setting is applied live through a CONFIG message, so sliders never
+    // restart the pet.  Starting a previously-disabled runtime is debounced
+    // to avoid spawning repeatedly while settings settle.
+    if (next.enabled === false) {
+      if (restartTimer) {
+        clearTimeout(restartTimer)
+        restartTimer = undefined
+      }
+      stopRuntime('settings-change')
+      return
+    }
+    if (!bridge) {
+      scheduleRestart(next)
+      return
+    }
+    if (restartTimer) {
+      clearTimeout(restartTimer)
+      restartTimer = undefined
+    }
+    applyLiveSettings(next)
+  })
+  if (typeof ctx.inject === 'function') {
+    ctx.inject(['webServer'], (httpCtx) => {
+      httpCtx.effect(
+        () => httpCtx.webServer.register({ kind: 'exact', path: CONFIG_ENDPOINT, handler: createConfigHandler(settings) }),
+        'dsh-dafeiyu: local settings endpoint',
+      )
+    })
+  }
+  ctx.effect(() => () => {
+    if (restartTimer) clearTimeout(restartTimer)
+    restartTimer = undefined
+    offEvent?.()
+    offDisposed?.()
+    unwatch()
+    stopRuntime('dsh-host-stop')
+  })
+}
+
+export function apply(ctx, config = {}) {
+  if (typeof ctx.inject === 'function') {
+    ctx.inject(['settings'], (settingsCtx) => mount(settingsCtx, config, ctx))
+    return
+  }
+  mount(ctx, config)
+}
+
+export {
+  CompanionMessageKind,
+  CompanionReducer,
+  CompanionState,
+  HelperProcess,
+}

--- a/test/entry-guard.test.js
+++ b/test/entry-guard.test.js
@@ -1,0 +1,30 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+test('entry guard keeps the loader working when a runtime dependency is missing', () => {
+  // The entry resolves './plugin.js' relative to its own location, so a temp
+  // directory with a broken plugin.js reproduces the incomplete-install case
+  // (issue #39) without uninstalling the real dependencies.
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-entry-guard-'))
+  writeFileSync(join(dir, 'index.js'), readFileSync(new URL('../src/index.js', import.meta.url)))
+  writeFileSync(
+    join(dir, 'plugin.js'),
+    "throw new Error(\"Cannot find package '@deepseek-ai/schemastery' imported from plugin.js\")\n",
+  )
+  const script = `const m = await import(${JSON.stringify(pathToFileURL(join(dir, 'index.js')).href)});`
+    + 'console.log(JSON.stringify({ name: m.name, inject: m.inject, apply: typeof m.apply }))'
+  const run = spawnSync(process.execPath, ['--input-type=module', '-e', script], { encoding: 'utf8' })
+  assert.equal(run.status, 0, `entry import failed: ${run.stderr}`)
+  assert.match(run.stderr, /Cannot find package '@deepseek-ai\/schemastery'/)
+  assert.match(run.stderr, /\[dsh-dafeiyu\].*自动停用/)
+  assert.match(run.stderr, /dsh plugin --profile web add/)
+  const exported = JSON.parse(run.stdout)
+  assert.equal(exported.name, 'dsh-dafeiyu')
+  assert.deepEqual(exported.inject, [])
+  assert.equal(exported.apply, 'function')
+})


### PR DESCRIPTION
## 背景

#39 报告的 `0.1.4` 启动失败：`link:` 方式安装时插件真实目录在 profile 外，Node 沿真实路径向上解析不到 `@deepseek-ai/schemastery`，ESM 静态导入在模块加载阶段直接抛 `ERR_MODULE_NOT_FOUND`，导致**整个 DSH 插件树加载失败**。`0.1.5` 已通过 bundleDependencies 修复 registry / tgz 主路径；本 PR 补上运行时兜底，即使依赖真的缺失也只停用桌宠，不影响 DSH 与其他插件。

## 改动

- 原插件整体移至 `src/plugin.js`（内容零改动）。
- `src/index.js` 变为加载守卫入口：动态 `import('./plugin.js')` 并 try/catch。
  - 正常路径行为不变（测试 `plugin-integration.test.js` 直接覆盖）。
  - 依赖缺失时：输出一条明确的 console 告警（缺什么 + 重装命令），导出惰性插件（`name` + 空转 `apply`），DSH 正常启动。

## 测试

- 新增 `test/entry-guard.test.js`：模拟坏依赖场景，断言入口仍可加载、告警包含原因与修复命令。
- 全套 JS 测试 72/72 通过。