### PR TITLE
docs: 把 #24 实测的 macOS Gatekeeper 结论写进双语文档

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Added
 
+- Document verified macOS Gatekeeper behavior in both READMEs (issue #24):
+  npm installs, terminal downloads, and browser-downloaded `.tgz` archives
+  installed directly never trigger Gatekeeper; only Finder-extracted `.app`
+  bundles carry quarantine attributes. Includes the recommended install flow,
+  terminal download commands, and the `xattr` cleanup for users who already
+  extracted with Finder.
 - Degrade gracefully when a packaged runtime dependency cannot be resolved
   (for example an incomplete `link:` install): the loader entry now imports
   the plugin behind a guard, logs one actionable notice naming the missing

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ pnpm dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
 
 > `0.1.4` 首次提供实验性的原生 macOS Helper。CI 已验证 Universal 架构、
 > AppKit 渲染和进程生命周期；Apple Silicon 实机体验将继续通过用户反馈验证。
-> 当前应用只有 ad-hoc 签名，尚未 Developer ID 签名或公证，浏览器下载的包可能
-> 被 Gatekeeper 拦截。
+> 当前应用只有 ad-hoc 签名，尚未 Developer ID 签名或公证。Gatekeeper 只在
+> 个别场景触发，放行方式见下方「关于 macOS Gatekeeper」。
 
 macOS 的安装方式与 Windows 相同，只是换成「终端」和 macOS 路径。发布包
 内置原生 Helper，**不需要安装 Python、PySide6 或 Xcode**。
@@ -204,6 +204,30 @@ pnpm dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
 ```
 
 装完照常启动 DSH WebUI，大肥鱼会由 DSH 自动拉起；不要手动打开 Helper。
+
+#### 关于 macOS Gatekeeper
+
+实测结论（见 issue [#24](https://github.com/QCYTSN/dsh-dafeiyu/issues/24)）：
+从 npm 安装、用终端下载、以及浏览器下载 `.tgz` 后**直接安装**，都不会触发
+Gatekeeper 拦截。只有用 Finder 解压出来的 `.app` 才会携带隔离标记，双击时
+被拦截。
+
+- 推荐做法：浏览器下载 `.tgz` 后**不要用 Finder 解压**，直接执行上面的安装
+  命令（npm/tar 解包不传播隔离标记）。
+- 用终端下载从一开始就不会产生隔离标记：
+
+  ```bash
+  gh release download --repo QCYTSN/dsh-dafeiyu
+  # 或者
+  curl -LO https://github.com/QCYTSN/dsh-dafeiyu/releases/download/v<版本>/dsh-dafeiyu-<版本>.tgz
+  ```
+
+- 如果已经用 Finder 解压并被拦截：右键该 Helper →「打开」放行一次，或者
+  清除隔离标记后运行：
+
+  ```bash
+  xattr -dr com.apple.quarantine <解压出的 dsh-dafeiyu-helper.app 路径>
+  ```
 
 ### 3. GitHub Release 备用安装方式
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -185,7 +185,8 @@ the Helper yourself.
 > CI verifies its universal architecture, AppKit rendering, and process lifecycle;
 > Apple Silicon experience will continue to be validated through user feedback.
 > The app currently has an ad-hoc signature, not a Developer ID signature or
-> notarization, so Gatekeeper may block browser-downloaded archives.
+> notarization. Gatekeeper only triggers in specific scenarios; see
+> "About macOS Gatekeeper" below.
 
 Installation on macOS is the same as Windows, just in the Terminal with macOS
 paths. The release bundle ships a native Helper — **no Python, PySide6 or Xcode
@@ -220,6 +221,33 @@ pnpm dsh plugin --profile web add ~/Downloads/dsh-dafeiyu-<version>.tgz
 
 Then launch DSH WebUI normally; BigFish is started automatically. Do not start
 the Helper yourself.
+
+#### About macOS Gatekeeper
+
+Verified conclusions (see issue
+[#24](https://github.com/QCYTSN/dsh-dafeiyu/issues/24)): installing from npm,
+downloading via the terminal, and installing a browser-downloaded `.tgz`
+**directly** all bypass Gatekeeper. Only an `.app` extracted with Finder
+carries the quarantine attribute and gets blocked on double-click.
+
+- Recommended: after downloading the `.tgz` in a browser, **do not extract it
+  with Finder** — run the install command above directly (npm/tar extraction
+  does not propagate quarantine attributes).
+- Downloading in a terminal never creates quarantine attributes in the first
+  place:
+
+  ```bash
+  gh release download --repo QCYTSN/dsh-dafeiyu
+  # or
+  curl -LO https://github.com/QCYTSN/dsh-dafeiyu/releases/download/v<version>/dsh-dafeiyu-<version>.tgz
+  ```
+
+- If you already extracted with Finder and got blocked: right-click the Helper
+  → "Open" once to allow it, or clear the quarantine attribute and run it:
+
+  ```bash
+  xattr -dr com.apple.quarantine <path to the extracted dsh-dafeiyu-helper.app>
+  ```
 
 ### 3. GitHub Release fallback
 


### PR DESCRIPTION
## 背景

#24 中 @palebule 提供了非常完整的 Gatekeeper 实测报告。本 PR 把结论落进 `README.md` / `README_EN.md` 的 macOS 安装章节：

- npm 安装、终端下载、浏览器下载 `.tgz` 后**直接安装**：均不触发 Gatekeeper。
- 仅 Finder 解压出的 `.app` 会携带隔离标记被拦截。
- 补充推荐安装流程、终端下载命令、以及 `xattr -dr com.apple.quarantine` 清理指引。
- 顺带修正了原 blockquote 中「浏览器下载的包可能被拦截」的不精确表述。

纯文档改动，Refs #24。