### PR TITLE
fix: 插件激活失败不再拖垮 DSH 启动（加载守卫之后的第二层防护）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- Keep the DSH host boot alive when plugin activation fails (for example a
+  host-side settings or web-server API change after a DSH update): activation
+  errors are now logged and the pet stays disabled for that session instead of
+  rejecting the whole plugin tree, matching the import-time guard shipped in
+  0.1.7.
+
 ## 0.1.7
 
 ### Changed

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -134,6 +134,17 @@ export function createConfigHandler(settings) {
 
 function mount(ctx, config = {}, eventCtx = ctx) {
   const logger = ctx.logger ?? console
+  try {
+    mountCompanion(ctx, config, eventCtx, logger)
+  } catch (error) {
+    // DSH treats a failing plugin activation as fatal for the whole boot
+    // (dsh-app-boot rethrows init rejections). A host-side API change must
+    // cost the pet its session, never the host its startup.
+    logger.error?.(`dsh-dafeiyu failed to activate and stays disabled for this session: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function mountCompanion(ctx, config = {}, eventCtx = ctx, logger) {
   const base = publicConfig(config)
   const settings = ctx.settings?.register?.('dsh-dafeiyu', Config, {
     base,
@@ -257,23 +268,29 @@ function mount(ctx, config = {}, eventCtx = ctx) {
     // setting is applied live through a CONFIG message, so sliders never
     // restart the pet.  Starting a previously-disabled runtime is debounced
     // to avoid spawning repeatedly while settings settle.
-    if (next.enabled === false) {
+    try {
+      if (next.enabled === false) {
+        if (restartTimer) {
+          clearTimeout(restartTimer)
+          restartTimer = undefined
+        }
+        stopRuntime('settings-change')
+        return
+      }
+      if (!bridge) {
+        scheduleRestart(next)
+        return
+      }
       if (restartTimer) {
         clearTimeout(restartTimer)
         restartTimer = undefined
       }
-      stopRuntime('settings-change')
-      return
+      applyLiveSettings(next)
+    } catch (error) {
+      // This callback runs inside the host's settings dispatch; a throw here
+      // would take the host's settings service down with the pet.
+      logger.error?.(`dsh-dafeiyu failed to apply settings: ${error instanceof Error ? error.message : String(error)}`)
     }
-    if (!bridge) {
-      scheduleRestart(next)
-      return
-    }
-    if (restartTimer) {
-      clearTimeout(restartTimer)
-      restartTimer = undefined
-    }
-    applyLiveSettings(next)
   })
   if (typeof ctx.inject === 'function') {
     ctx.inject(['webServer'], (httpCtx) => {

--- a/test/plugin-integration.test.js
+++ b/test/plugin-integration.test.js
@@ -24,6 +24,16 @@ test('package metadata exposes the DSH web client bundle', () => {
   ])
 })
 
+test('activation failure degrades to a disabled pet instead of failing the host', () => {
+  const errors = []
+  const ctx = {
+    logger: { debug() {}, info() {}, warn() {}, error(message) { errors.push(message) } },
+    settings: { register: () => { throw new Error('host settings API changed') } },
+  }
+  assert.doesNotThrow(() => apply(ctx, {}))
+  assert.ok(errors.some((message) => message.includes('failed to activate')))
+})
+
 async function waitFor(predicate, timeoutMs = 5000) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {


### PR DESCRIPTION
## 背景

有用户反馈「DSH 更新后插件不可用 / 疑似插件导致 DSH 启动失败」。我们在 Windows + Node 24 上对 **DSH 0.1.2-rc.1**（9月3日 发布的最新版）做了完整兼容性复现：干净安装、旧时代真实目录布局、0.1.6/0.1.7 两个插件版本**全部正常启动**，helper 握手正常，暂时无法在本地复现该反馈。

但排查中发现一个结构性缺口：新版 `dsh-app-boot` 对插件**激活阶段**（`apply` / settings 注册 / webServer 注册）抛出的异常同样是整树否决——0.1.7 的守卫只覆盖了模块**加载**阶段。如果 DSH 更新改了宿主 API，本插件的激活异常依然可能拖死 DSH 启动。

## 改动

- `mount()` 整体包一层守卫：激活抛错时记录一条明确日志，桌宠本次会话自动禁用，**绝不上抛**。
- `settings.watch` 回调同样包一层：该回调运行在宿主的 settings 派发内，抛错会连带宿主的 settings 服务。
- 新增测试：`settings.register` 抛错时 `apply` 不抛、日志包含 `failed to activate`。

## 测试

- 全套 JS 测试 73/73 通过（72 旧 + 1 新）。